### PR TITLE
security: pin axios below compromised v1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "git+https://github.com/BurtTheCoder/mcp-virustotal.git"
   },
   "dependencies": {
-    "axios": "^1.4.0",
+    "axios": ">=1.4.0 <1.14.1",
     "dotenv": "^16.4.5",
     "fastmcp": "~3.25.4",
     "zod": "^3.22.2"


### PR DESCRIPTION
Pins axios below v1.14.1 to avoid supply chain attack (https://socket.dev/blog/axios-npm-package-compromised). axios@1.14.1 and axios@0.30.4 include a malicious dependency (plain-crypto-js) that deploys a RAT.