### PR TITLE
Fix bugs, sync with current VT API docs, parallelize report fetches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.4.0",
+        "axios": ">=1.4.0 <1.14.1",
         "dotenv": "^16.4.5",
         "fastmcp": "~3.25.4",
         "zod": "^3.22.2"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build": "tsc && chmod +x build/index.js",
     "start": "node build/index.js",
     "dev": "tsc -w",
+    "test": "npm run build && node --test tests/*.test.mjs",
+    "smoke": "npm run build && node scripts/smoke-test.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Live smoke test against the VirusTotal API. Requires VIRUSTOTAL_API_KEY.
+// Paces calls at ~20s to stay under the 500/day, 4/min public quota.
+// Usage: npm run smoke
+import { initVirusTotalClient } from '../build/utils/api.js';
+import {
+  handleGetUrlReport,
+  handleGetUrlRelationship,
+  handleGetFileReport,
+  handleGetFileRelationship,
+  handleGetFileBehaviourSummary,
+  handleGetIpReport,
+  handleGetIpRelationship,
+  handleGetDomainReport,
+  handleGetDomainRelationship,
+  handleSearch,
+  handleGetCollection,
+} from '../build/handlers/index.js';
+
+if (!process.env.VIRUSTOTAL_API_KEY) {
+  console.error('Set VIRUSTOTAL_API_KEY first');
+  process.exit(1);
+}
+
+initVirusTotalClient();
+
+const PACING_MS = 20000;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Known-good IOCs
+const EICAR_SHA256 = '275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f';
+const WANNACRY_SHA256 = 'ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa';
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+
+async function run(name, fn) {
+  const start = Date.now();
+  try {
+    const result = await fn();
+    const text = result?.content?.[0]?.text || '';
+    const lines = text.split('\n');
+    console.log(`\n✓ ${name} — ${Date.now() - start}ms, ${text.length} chars, ${lines.length} lines`);
+    console.log(lines.slice(0, 6).join('\n').replace(/^/gm, '    '));
+    if (lines.length > 6) console.log(`    … (${lines.length - 6} more lines)`);
+    pass++;
+  } catch (err) {
+    console.log(`\n✗ ${name}\n    ${err.message}`);
+    failures.push({ name, message: err.message });
+    fail++;
+  }
+}
+
+const tests = [
+  ['get_domain_report (google.com)', () => handleGetDomainReport({ domain: 'google.com' })],
+  ['get_domain_relationship (subdomains)', () => handleGetDomainRelationship({ domain: 'google.com', relationship: 'subdomains', limit: 5 })],
+  ['get_ip_report (8.8.8.8)', () => handleGetIpReport({ ip: '8.8.8.8' })],
+  ['get_ip_relationship (resolutions)', () => handleGetIpRelationship({ ip: '8.8.8.8', relationship: 'resolutions', limit: 5 })],
+  ['get_url_report (https://www.google.com)', () => handleGetUrlReport({ url: 'https://www.google.com' })],
+  ['get_url_relationship (contacted_domains)', () => handleGetUrlRelationship({ url: 'https://www.google.com', relationship: 'contacted_domains', limit: 5 })],
+  ['get_file_report (EICAR)', () => handleGetFileReport({ hash: EICAR_SHA256 })],
+  ['get_file_relationship (similar_files)', () => handleGetFileRelationship({ hash: EICAR_SHA256, relationship: 'similar_files', limit: 5 })],
+  ['get_file_behaviour_summary (WannaCry)', () => handleGetFileBehaviourSummary({ hash: WANNACRY_SHA256 })],
+  ['search_vt (query: google.com)', () => handleSearch({ query: 'google.com', limit: 5 })],
+  ['get_collection (probably-404)', () => handleGetCollection({ id: 'threat-actor--apt28' })],
+];
+
+console.log(`\nRunning ${tests.length} live smoke tests (pacing ${PACING_MS / 1000}s between calls)…`);
+console.log(`Expected duration: ~${Math.round((tests.length * PACING_MS) / 1000)}s\n`);
+
+let first = true;
+for (const [name, fn] of tests) {
+  if (!first) await sleep(PACING_MS);
+  first = false;
+  await run(name, fn);
+}
+
+console.log(`\n\n=== ${pass} passed, ${fail} failed ===`);
+if (failures.length) {
+  console.log('\nFailures:');
+  for (const f of failures) console.log(`  - ${f.name}: ${f.message}`);
+}
+process.exit(fail > 0 ? 1 : 0);

--- a/src/formatters/behaviour.ts
+++ b/src/formatters/behaviour.ts
@@ -1,0 +1,94 @@
+import { FormattedResult } from './types.js';
+import { logToFile } from '../utils/logging.js';
+
+const PREVIEW = 10;
+
+function section(title: string, items: any[] | undefined, render: (item: any) => string): string[] {
+  if (!items || items.length === 0) return [];
+  const preview = items.slice(0, PREVIEW).map(render).filter(Boolean);
+  const more = items.length > PREVIEW ? `    … and ${items.length - PREVIEW} more` : null;
+  return [`${title} (${items.length}):`, ...preview.map((line) => `  - ${line}`), ...(more ? [more] : []), ''];
+}
+
+export function formatBehaviourSummary(hash: string, data: any): FormattedResult {
+  try {
+    if (!data) {
+      return { type: 'text', text: `No sandbox behaviour summary available for ${hash}.` };
+    }
+
+    const lines: string[] = [
+      `🧪 Sandbox Behaviour Summary`,
+      `File: ${hash}`,
+      '',
+    ];
+
+    if (data.verdicts?.length) {
+      lines.push(`Verdicts: ${data.verdicts.join(', ')}`, '');
+    }
+    if (data.tags?.length) {
+      lines.push(`Behaviour Tags: ${data.tags.join(', ')}`, '');
+    }
+    if (data.mitre_attack_techniques?.length) {
+      lines.push('🎯 MITRE ATT&CK Techniques:');
+      for (const t of data.mitre_attack_techniques.slice(0, PREVIEW)) {
+        const id = t.id || t.signature_id || 'T?';
+        const name = t.signature_description || t.description || '';
+        const severity = t.severity ? ` [${t.severity}]` : '';
+        lines.push(`  - ${id}${severity} ${name}`.trim());
+      }
+      if (data.mitre_attack_techniques.length > PREVIEW) {
+        lines.push(`    … and ${data.mitre_attack_techniques.length - PREVIEW} more`);
+      }
+      lines.push('');
+    }
+
+    lines.push(
+      ...section('🔧 Processes Created', data.processes_created, (p) => String(p)),
+      ...section('💉 Processes Injected', data.processes_injected, (p) => String(p)),
+      ...section('💀 Processes Terminated', data.processes_terminated, (p) => String(p)),
+      ...section('⌨️  Command Executions', data.command_executions, (c) => String(c)),
+      ...section('📂 Files Opened', data.files_opened, (f) => String(f)),
+      ...section('✏️  Files Written', data.files_written, (f) => String(f)),
+      ...section('📦 Files Dropped', data.files_dropped, (f) => `${f.path || ''} ${f.sha256 ? `(${f.sha256})` : ''}`.trim()),
+      ...section('🗑️  Files Deleted', data.files_deleted, (f) => String(f)),
+      ...section('🔑 Registry Keys Opened', data.registry_keys_opened, (r) => String(r)),
+      ...section('📝 Registry Keys Set', data.registry_keys_set, (r) => `${r.key || ''} = ${r.value || ''}`.trim()),
+      ...section('🧹 Registry Keys Deleted', data.registry_keys_deleted, (r) => String(r)),
+      ...section('🌐 DNS Lookups', data.dns_lookups, (d) => `${d.hostname || ''}${d.resolved_ips?.length ? ` → ${d.resolved_ips.join(', ')}` : ''}`.trim()),
+      ...section('📡 IP Traffic', data.ip_traffic, (t) => `${t.transport_layer_protocol || ''} ${t.destination_ip || ''}:${t.destination_port || ''}`.trim()),
+      ...section('🌍 HTTP Conversations', data.http_conversations, (h) => `${h.request_method || 'GET'} ${h.url || ''}`.trim()),
+      ...section('🔒 Mutexes Created', data.mutexes_created, (m) => String(m)),
+      ...section('📚 Modules Loaded', data.modules_loaded, (m) => String(m)),
+    );
+
+    if (data.ids_results?.length) {
+      lines.push(`🛡️  IDS Alerts (${data.ids_results.length}):`);
+      for (const r of data.ids_results.slice(0, PREVIEW)) {
+        const ctx = r.alert_context?.[0] || {};
+        lines.push(
+          `  - ${r.rule_msg || r.rule_id || 'alert'} [${r.alert_severity || 'info'}]`,
+          `      ${ctx.proto || ''} ${ctx.src_ip || ''}:${ctx.src_port || ''} → ${ctx.dest_ip || ''}:${ctx.dest_port || ''}`.replace(/\s+/g, ' ').trim(),
+        );
+      }
+      if (data.ids_results.length > PREVIEW) {
+        lines.push(`    … and ${data.ids_results.length - PREVIEW} more`);
+      }
+      lines.push('');
+    }
+
+    if (data.signature_matches?.length) {
+      lines.push(`🚨 Signature Matches (${data.signature_matches.length}):`);
+      for (const s of data.signature_matches.slice(0, PREVIEW)) {
+        lines.push(`  - ${s.id || ''} [${s.severity || 'info'}] ${s.description || ''}`.trim());
+      }
+      if (data.signature_matches.length > PREVIEW) {
+        lines.push(`    … and ${data.signature_matches.length - PREVIEW} more`);
+      }
+    }
+
+    return { type: 'text', text: lines.join('\n').trimEnd() };
+  } catch (error) {
+    logToFile(`Error formatting behaviour summary: ${error}`);
+    return { type: 'text', text: 'Error formatting behaviour summary' };
+  }
+}

--- a/src/formatters/collection.ts
+++ b/src/formatters/collection.ts
@@ -1,0 +1,99 @@
+import { FormattedResult } from './types.js';
+import { formatDateTime } from './utils.js';
+import { logToFile } from '../utils/logging.js';
+
+interface CollectionData {
+  type?: string;
+  id?: string;
+  attributes?: {
+    name?: string;
+    description?: string;
+    collection_type?: string;
+    tags?: string[];
+    targeted_regions?: string[];
+    targeted_industries?: string[];
+    source_region?: string;
+    motivations?: string[];
+    threat_categories?: string[];
+    aliases?: string[];
+    creation_date?: number;
+    last_modification_date?: number;
+    files_count?: number;
+    urls_count?: number;
+    domains_count?: number;
+    ip_addresses_count?: number;
+    references_count?: number;
+    [key: string]: any;
+  };
+  relationships?: Record<string, { data: any; meta?: { count?: number } }>;
+}
+
+function formatCounts(attrs: NonNullable<CollectionData['attributes']>): string[] {
+  const counts: string[] = [];
+  if (attrs.files_count != null) counts.push(`📁 Files: ${attrs.files_count}`);
+  if (attrs.urls_count != null) counts.push(`🔗 URLs: ${attrs.urls_count}`);
+  if (attrs.domains_count != null) counts.push(`🌍 Domains: ${attrs.domains_count}`);
+  if (attrs.ip_addresses_count != null) counts.push(`🌐 IPs: ${attrs.ip_addresses_count}`);
+  if (attrs.references_count != null) counts.push(`📚 References: ${attrs.references_count}`);
+  return counts;
+}
+
+export function formatCollectionResults(data: CollectionData): FormattedResult {
+  try {
+    const attrs = data?.attributes || {};
+    const lines: string[] = [
+      `📚 Collection: ${attrs.name || data?.id || 'Unknown'}`,
+      `ID: ${data?.id || 'Unknown'}`,
+      attrs.collection_type ? `Type: ${attrs.collection_type}` : null,
+      '',
+    ].filter((line): line is string => line !== null);
+
+    if (attrs.description) {
+      lines.push('Description:', attrs.description, '');
+    }
+
+    if (attrs.aliases?.length) lines.push(`Aliases: ${attrs.aliases.join(', ')}`);
+    if (attrs.tags?.length) lines.push(`Tags: ${attrs.tags.join(', ')}`);
+    if (attrs.threat_categories?.length) lines.push(`Threat Categories: ${attrs.threat_categories.join(', ')}`);
+    if (attrs.motivations?.length) lines.push(`Motivations: ${attrs.motivations.join(', ')}`);
+    if (attrs.source_region) lines.push(`Source Region: ${attrs.source_region}`);
+    if (attrs.targeted_regions?.length) lines.push(`Targeted Regions: ${attrs.targeted_regions.join(', ')}`);
+    if (attrs.targeted_industries?.length) lines.push(`Targeted Industries: ${attrs.targeted_industries.join(', ')}`);
+
+    const counts = formatCounts(attrs);
+    if (counts.length) {
+      lines.push('', 'IOC Counts:', ...counts.map((c) => `• ${c}`));
+    }
+
+    if (attrs.creation_date) lines.push(`\nCreated: ${formatDateTime(attrs.creation_date)}`);
+    if (attrs.last_modification_date) lines.push(`Last Modified: ${formatDateTime(attrs.last_modification_date)}`);
+
+    if (data.relationships) {
+      lines.push('', '🔗 Included Relationships:');
+      for (const [relType, relData] of Object.entries(data.relationships)) {
+        const items = Array.isArray(relData.data) ? relData.data : relData.data ? [relData.data] : [];
+        const count = relData.meta?.count ?? items.length;
+        lines.push(`\n${relType} (${count} items):`);
+        for (const item of items.slice(0, 10)) {
+          const attrs = item.attributes || {};
+          const label =
+            attrs.meaningful_name ||
+            attrs.url ||
+            attrs.ip_address ||
+            attrs.name ||
+            item.id ||
+            'unknown';
+          lines.push(`  • ${label}`);
+        }
+        if (items.length > 10) {
+          lines.push(`    … and ${items.length - 10} more`);
+        }
+      }
+    }
+
+    return { type: 'text', text: lines.join('\n').trimEnd() };
+  } catch (error) {
+    logToFile(`Error formatting collection results: ${error}`);
+    return { type: 'text', text: 'Error formatting collection results' };
+  }
+}

--- a/src/formatters/file.ts
+++ b/src/formatters/file.ts
@@ -87,7 +87,7 @@ function formatRelationshipData(relType: string, item: any): string {
 
       const network = attrs.ids_results?.map((result: any) => {
         const ctx = result.alert_context || {};
-        return `${result.rule_msg} (${ctx.protocol || 'unknown'} ${ctx.src_ip || ''}:${ctx.src_port || ''} -> ${ctx.dest_ip || ''}:${ctx.dest_port || ''})`;
+        return `${result.rule_msg} (${ctx.proto || 'unknown'} ${ctx.src_ip || ''}:${ctx.src_port || ''} -> ${ctx.dest_ip || ''}:${ctx.dest_port || ''})`;
       }) || [];
 
       return `  • Sandbox: ${attrs.sandbox_name || 'Unknown'}

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -7,3 +7,6 @@ export { formatFileResults } from './file.js';
 export { formatIpResults } from './ip.js';
 export { formatDomainResults } from './domain.js';
 export { formatRelationshipResults } from './relationship.js';
+export { formatSearchResults } from './search.js';
+export { formatBehaviourSummary } from './behaviour.js';
+export { formatCollectionResults } from './collection.js';

--- a/src/formatters/search.ts
+++ b/src/formatters/search.ts
@@ -1,0 +1,83 @@
+import { FormattedResult } from './types.js';
+import { formatDateTime } from './utils.js';
+import { logToFile } from '../utils/logging.js';
+
+interface SearchItem {
+  type: string;
+  id: string;
+  attributes?: Record<string, any>;
+}
+
+interface SearchMeta {
+  cursor?: string;
+  count?: number;
+}
+
+function formatItem(item: SearchItem): string {
+  const attrs = item.attributes || {};
+  const stats = attrs.last_analysis_stats || {};
+  const detection = stats.malicious !== undefined
+    ? `🔴 ${stats.malicious} malicious / ${(stats.malicious || 0) + (stats.suspicious || 0) + (stats.harmless || 0) + (stats.undetected || 0)} engines`
+    : '';
+
+  switch (item.type) {
+    case 'file': {
+      const name = attrs.meaningful_name || attrs.names?.[0] || item.id;
+      const fileType = attrs.type_description || attrs.type_tag || 'Unknown';
+      const seen = attrs.first_submission_date ? formatDateTime(attrs.first_submission_date) : 'Unknown';
+      return `📁 file • ${name}
+    SHA-256: ${attrs.sha256 || item.id}
+    Type: ${fileType}
+    First Seen: ${seen}${detection ? `\n    Detection: ${detection}` : ''}`;
+    }
+    case 'url': {
+      const url = attrs.url || item.id;
+      const title = attrs.title ? `\n    Title: ${attrs.title}` : '';
+      return `🔗 url • ${url}${title}${detection ? `\n    Detection: ${detection}` : ''}`;
+    }
+    case 'domain':
+      return `🌍 domain • ${item.id}${detection ? `\n    Detection: ${detection}` : ''}`;
+    case 'ip_address':
+      return `🌐 ip • ${item.id}
+    AS: ${attrs.as_owner || 'Unknown'} (${attrs.country || '?'})${detection ? `\n    Detection: ${detection}` : ''}`;
+    case 'comment':
+      return `💬 comment • ${item.id}
+    ${(attrs.text || '').slice(0, 200)}${attrs.text && attrs.text.length > 200 ? '…' : ''}`;
+    default:
+      return `• ${item.type} • ${item.id}`;
+  }
+}
+
+export function formatSearchResults(
+  query: string,
+  data: SearchItem[],
+  meta?: SearchMeta,
+): FormattedResult {
+  try {
+    const items = Array.isArray(data) ? data : [];
+    const lines: string[] = [
+      `🔎 VirusTotal Search Results`,
+      `Query: ${query}`,
+      `Results: ${items.length}${meta?.count ? ` of ${meta.count}` : ''}`,
+      '',
+    ];
+
+    if (items.length === 0) {
+      lines.push('No matching objects found.');
+    } else {
+      for (const item of items) {
+        lines.push(formatItem(item));
+        lines.push('');
+      }
+    }
+
+    if (meta?.cursor) {
+      lines.push(`📄 More results available. Pass cursor: ${meta.cursor}`);
+    }
+
+    return { type: 'text', text: lines.join('\n').trimEnd() };
+  } catch (error) {
+    logToFile(`Error formatting search results: ${error}`);
+    return { type: 'text', text: 'Error formatting search results' };
+  }
+}

--- a/src/handlers/collection.ts
+++ b/src/handlers/collection.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
+import { formatCollectionResults } from '../formatters/index.js';
+import { GetCollectionArgsSchema } from '../schemas/index.js';
+import { logToFile } from '../utils/logging.js';
+
+export async function handleGetCollection(args: z.infer<typeof GetCollectionArgsSchema>) {
+  const { id, relationships } = args;
+  logToFile(`Getting collection ${id}${relationships ? ` with relationships: ${relationships.join(',')}` : ''}`);
+
+  const result = relationships && relationships.length > 0
+    ? await queryVirusTotalWithRelationships(`/collections/${id}`, relationships)
+    : await queryVirusTotal(`/collections/${id}`);
+
+  return {
+    content: [formatCollectionResults(result.data)],
+  };
+}

--- a/src/handlers/domain.ts
+++ b/src/handlers/domain.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
-import { queryVirusTotalWithRelationships } from '../utils/api.js';
+import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
 import { formatDomainResults } from '../formatters/index.js';
-import { GetDomainReportArgsSchema } from '../schemas/index.js';
+import {
+  GetDomainReportArgsSchema,
+  GetDomainRelationshipArgsSchema,
+} from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
 import { RelationshipItem, RelationshipData, DomainResponse } from '../types/virustotal.js';
 
@@ -134,5 +137,51 @@ export async function handleGetDomainReport(args: z.infer<typeof GetDomainReport
 
   return {
     content: [formatDomainResults(combinedData)],
+  };
+}
+
+export async function handleGetDomainRelationship(
+  args: z.infer<typeof GetDomainRelationshipArgsSchema>,
+) {
+  const { domain, relationship, limit, cursor } = args;
+
+  const params: Record<string, string | number> = { limit };
+  if (cursor) params.cursor = cursor;
+
+  logToFile(`Fetching ${relationship} for domain: ${domain}`);
+  const result = await queryVirusTotal(
+    `/domains/${domain}/${relationship}`,
+    'get',
+    undefined,
+    params,
+  );
+
+  // Attach formattedOutput for the existing domain formatter.
+  const relationshipData: Record<string, RelationshipData> = {};
+  if (Array.isArray(result.data)) {
+    relationshipData[relationship] = {
+      data: result.data.map((item: RelationshipItem) => ({
+        ...item,
+        formattedOutput: formatRelationshipData(relationship, item),
+      })),
+      meta: result.meta,
+    };
+  } else if (result.data) {
+    relationshipData[relationship] = {
+      data: {
+        ...result.data,
+        formattedOutput: formatRelationshipData(relationship, result.data),
+      },
+      meta: result.meta,
+    };
+  }
+
+  return {
+    content: [
+      formatDomainResults({
+        id: domain,
+        relationships: relationshipData,
+      }),
+    ],
   };
 }

--- a/src/handlers/domain.ts
+++ b/src/handlers/domain.ts
@@ -1,151 +1,138 @@
 import { z } from 'zod';
-import { queryVirusTotal } from '../utils/api.js';
+import { queryVirusTotalWithRelationships } from '../utils/api.js';
 import { formatDomainResults } from '../formatters/index.js';
 import { GetDomainReportArgsSchema } from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
 import { RelationshipItem, RelationshipData, DomainResponse } from '../types/virustotal.js';
 
-// Default relationships to fetch if none specified
 const DEFAULT_RELATIONSHIPS = [
-    'historical_whois',
-    'historical_ssl_certificates',
-    'resolutions',
-    'communicating_files',
-    'downloaded_files',
-    'referrer_files'
+  'historical_whois',
+  'historical_ssl_certificates',
+  'resolutions',
+  'communicating_files',
+  'downloaded_files',
+  'referrer_files',
 ] as const;
 
 function formatDate(dateStr: string | number): string {
-    try {
-        if (typeof dateStr === 'number') {
-            return new Date(dateStr * 1000).toLocaleDateString();
-        }
-        return new Date(dateStr).toLocaleDateString();
-    } catch {
-        return 'Unknown';
+  try {
+    if (typeof dateStr === 'number') {
+      return new Date(dateStr * 1000).toLocaleDateString();
     }
+    return new Date(dateStr).toLocaleDateString();
+  } catch {
+    return 'Unknown';
+  }
 }
 
 function formatRelationshipData(relType: string, item: RelationshipItem): string {
-    const attrs = item.attributes || {};
-    
-    switch (relType) {
-        case 'resolutions':
-            return `  • IP: ${attrs.ip_address} (${attrs.date ? new Date(Number(attrs.date) * 1000).toLocaleDateString() : 'Unknown'})
+  const attrs = item.attributes || {};
+
+  switch (relType) {
+    case 'resolutions':
+      return `  • IP: ${attrs.ip_address} (${attrs.date ? new Date(Number(attrs.date) * 1000).toLocaleDateString() : 'Unknown'})
     Host: ${attrs.host_name || 'Unknown'}
     Analysis Stats:
     - IP: 🔴 ${attrs.ip_address_last_analysis_stats?.malicious || 0} malicious, ✅ ${attrs.ip_address_last_analysis_stats?.harmless || 0} harmless
     - Host: 🔴 ${attrs.host_name_last_analysis_stats?.malicious || 0} malicious, ✅ ${attrs.host_name_last_analysis_stats?.harmless || 0} harmless`;
-            
-        case 'communicating_files':
-            return `  • ${attrs.meaningful_name || item.id}
+
+    case 'communicating_files':
+      return `  • ${attrs.meaningful_name || item.id}
     Type: ${attrs.type_description || attrs.type || 'Unknown'}
     First Seen: ${attrs.first_submission_date ? new Date(attrs.first_submission_date * 1000).toLocaleDateString() : 'Unknown'}`;
-            
-        case 'downloaded_files':
-            return `  • ${attrs.meaningful_name || item.id}
+
+    case 'downloaded_files':
+      return `  • ${attrs.meaningful_name || item.id}
     Type: ${attrs.type_description || attrs.type || 'Unknown'}
     First Seen: ${attrs.first_submission_date ? new Date(attrs.first_submission_date * 1000).toLocaleDateString() : 'Unknown'}`;
-            
-        case 'urls':
-            return `  • ${attrs.url || item.id}
+
+    case 'urls':
+      return `  • ${attrs.url || item.id}
     Last Analysis: ${attrs.last_analysis_date ? new Date(attrs.last_analysis_date * 1000).toLocaleDateString() : 'Unknown'}
     Reputation: ${attrs.reputation ?? 'Unknown'}`;
 
-        case 'historical_whois':
-            const whoisMap = attrs.whois_map || {};
-            const whoisInfo = [];
-            if (whoisMap['Registrar']) whoisInfo.push(`Registrar: ${whoisMap['Registrar']}`);
-            if (whoisMap['Creation Date']) whoisInfo.push(`Created: ${formatDate(whoisMap['Creation Date'])}`);
-            if (whoisMap['Registry Expiry Date']) whoisInfo.push(`Expires: ${formatDate(whoisMap['Registry Expiry Date'])}`);
-            if (whoisMap['Updated Date']) whoisInfo.push(`Updated: ${formatDate(whoisMap['Updated Date'])}`);
-            if (whoisMap['Registrant Organization']) whoisInfo.push(`Organization: ${whoisMap['Registrant Organization']}`);
-            if (attrs.registrar_name) whoisInfo.push(`Registrar: ${attrs.registrar_name}`);
-            return `  • WHOIS Record from ${formatDate(attrs.last_updated || '')}${whoisInfo.length ? '\n    ' + whoisInfo.join('\n    ') : ''}`;
-
-        case 'historical_ssl_certificates':
-            const certInfo = [];
-            if (attrs.subject?.CN) certInfo.push(`Subject: ${attrs.subject.CN}`);
-            if (attrs.issuer?.CN) certInfo.push(`Issuer: ${attrs.issuer.CN}`);
-            if (attrs.validity?.not_before) certInfo.push(`Valid From: ${formatDate(attrs.validity.not_before)}`);
-            if (attrs.validity?.not_after) certInfo.push(`Valid Until: ${formatDate(attrs.validity.not_after)}`);
-            if (attrs.serial_number) certInfo.push(`Serial: ${attrs.serial_number}`);
-            const altNames = attrs.extensions?.subject_alternative_name;
-            if (altNames && altNames.length) certInfo.push(`Alt Names: ${altNames.join(', ')}`);
-            return `  • SSL Certificate${certInfo.length ? '\n    ' + certInfo.join('\n    ') : ''}`;
-
-        case 'referrer_files':
-            const stats = attrs.last_analysis_stats || {};
-            const totalDetections = (Object.values(stats) as number[]).reduce((a, b) => a + b, 0);
-            return `  • ${attrs.meaningful_name || item.id}
-    Type: ${attrs.type_description || attrs.type || 'Unknown'}
-    Detection Ratio: ${attrs.last_analysis_stats ? 
-        `${attrs.last_analysis_stats.malicious}/${totalDetections}` : 
-        'Unknown'}`;
-            
-        default:
-            if (attrs.hostname) return `  • ${attrs.hostname}`;
-            if (attrs.ip_address) return `  • ${attrs.ip_address}`;
-            if (attrs.url) return `  • ${attrs.url}`;
-            if (attrs.value) return `  • ${attrs.value}`;
-            return `  • ${item.id}`;
+    case 'historical_whois': {
+      const whoisMap = attrs.whois_map || {};
+      const whoisInfo = [];
+      if (whoisMap['Registrar']) whoisInfo.push(`Registrar: ${whoisMap['Registrar']}`);
+      if (whoisMap['Creation Date']) whoisInfo.push(`Created: ${formatDate(whoisMap['Creation Date'])}`);
+      if (whoisMap['Registry Expiry Date']) whoisInfo.push(`Expires: ${formatDate(whoisMap['Registry Expiry Date'])}`);
+      if (whoisMap['Updated Date']) whoisInfo.push(`Updated: ${formatDate(whoisMap['Updated Date'])}`);
+      if (whoisMap['Registrant Organization']) whoisInfo.push(`Organization: ${whoisMap['Registrant Organization']}`);
+      if (attrs.registrar_name) whoisInfo.push(`Registrar: ${attrs.registrar_name}`);
+      const lastUpdated = attrs.last_updated ? formatDate(attrs.last_updated) : 'Unknown';
+      return `  • WHOIS Record from ${lastUpdated}${whoisInfo.length ? '\n    ' + whoisInfo.join('\n    ') : ''}`;
     }
+
+    case 'historical_ssl_certificates': {
+      const certInfo = [];
+      if (attrs.subject?.CN) certInfo.push(`Subject: ${attrs.subject.CN}`);
+      if (attrs.issuer?.CN) certInfo.push(`Issuer: ${attrs.issuer.CN}`);
+      if (attrs.validity?.not_before) certInfo.push(`Valid From: ${formatDate(attrs.validity.not_before)}`);
+      if (attrs.validity?.not_after) certInfo.push(`Valid Until: ${formatDate(attrs.validity.not_after)}`);
+      if (attrs.serial_number) certInfo.push(`Serial: ${attrs.serial_number}`);
+      const altNames = attrs.extensions?.subject_alternative_name;
+      if (altNames && altNames.length) certInfo.push(`Alt Names: ${altNames.join(', ')}`);
+      return `  • SSL Certificate${certInfo.length ? '\n    ' + certInfo.join('\n    ') : ''}`;
+    }
+
+    case 'referrer_files': {
+      const stats = attrs.last_analysis_stats || {};
+      const totalDetections = (Object.values(stats) as number[]).reduce((a, b) => a + b, 0);
+      return `  • ${attrs.meaningful_name || item.id}
+    Type: ${attrs.type_description || attrs.type || 'Unknown'}
+    Detection Ratio: ${attrs.last_analysis_stats
+        ? `${attrs.last_analysis_stats.malicious}/${totalDetections}`
+        : 'Unknown'}`;
+    }
+
+    default:
+      if (attrs.hostname) return `  • ${attrs.hostname}`;
+      if (attrs.ip_address) return `  • ${attrs.ip_address}`;
+      if (attrs.url) return `  • ${attrs.url}`;
+      if (attrs.value) return `  • ${attrs.value}`;
+      return `  • ${item.id}`;
+  }
 }
 
 export async function handleGetDomainReport(args: z.infer<typeof GetDomainReportArgsSchema>) {
-    const { domain, relationships = DEFAULT_RELATIONSHIPS } = args;
+  const { domain, relationships = DEFAULT_RELATIONSHIPS } = args;
 
-    // First get the basic domain report
-    logToFile('Getting domain report...');
-    const basicReport = await queryVirusTotal(
-        `/domains/${domain}`,
-        'get'
-    ) as DomainResponse;
+  logToFile('Getting domain report with relationships...');
+  const report = (await queryVirusTotalWithRelationships(
+    `/domains/${domain}`,
+    relationships,
+  )) as DomainResponse;
 
-    // Then get full data for specified relationships
-    const relationshipData: Record<string, RelationshipData> = {};
-    
-    for (const relType of relationships) {
-        logToFile(`Getting full data for ${relType}...`);
-        try {
-            const response = await queryVirusTotal(
-                `/domains/${domain}/${relType}`,
-                'get'
-            );
-
-            // Format the relationship data
-            if (Array.isArray(response.data)) {
-                relationshipData[relType] = {
-                    data: response.data.map((item: RelationshipItem) => ({
-                        ...item,
-                        formattedOutput: formatRelationshipData(relType, item)
-                    })),
-                    meta: response.meta
-                };
-            } else if (response.data) {
-                relationshipData[relType] = {
-                    data: {
-                        ...response.data,
-                        formattedOutput: formatRelationshipData(relType, response.data)
-                    },
-                    meta: response.meta
-                };
-            }
-        } catch (error) {
-            logToFile(`Error fetching ${relType} data: ${error}`);
-            // Continue with other relationships even if one fails
-        }
+  // Attach formattedOutput to each relationship item for the formatter.
+  const relationshipData: Record<string, RelationshipData> = {};
+  for (const [relType, relData] of Object.entries(report.data?.relationships || {})) {
+    const typed = relData as RelationshipData;
+    if (Array.isArray(typed.data)) {
+      relationshipData[relType] = {
+        data: typed.data.map((item: RelationshipItem) => ({
+          ...item,
+          formattedOutput: formatRelationshipData(relType, item),
+        })),
+        meta: typed.meta,
+      };
+    } else if (typed.data) {
+      relationshipData[relType] = {
+        data: {
+          ...typed.data,
+          formattedOutput: formatRelationshipData(relType, typed.data),
+        },
+        meta: typed.meta,
+      };
     }
+  }
 
-    // Combine the basic report with detailed relationships
-    const combinedData = {
-        ...basicReport.data,
-        relationships: relationshipData
-    };
+  const combinedData = {
+    ...report.data,
+    relationships: relationshipData,
+  };
 
-    return {
-        content: [
-            formatDomainResults(combinedData)
-        ],
-    };
+  return {
+    content: [formatDomainResults(combinedData)],
+  };
 }

--- a/src/handlers/file.ts
+++ b/src/handlers/file.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
-import { formatFileResults } from '../formatters/index.js';
-import { GetFileReportArgsSchema, GetFileRelationshipArgsSchema } from '../schemas/index.js';
+import { formatFileResults, formatBehaviourSummary } from '../formatters/index.js';
+import {
+  GetFileReportArgsSchema,
+  GetFileRelationshipArgsSchema,
+  GetFileBehaviourSummaryArgsSchema,
+} from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
 
 const DEFAULT_RELATIONSHIPS = [
@@ -57,5 +61,16 @@ export async function handleGetFileRelationship(args: z.infer<typeof GetFileRela
         },
       }),
     ],
+  };
+}
+
+export async function handleGetFileBehaviourSummary(
+  args: z.infer<typeof GetFileBehaviourSummaryArgsSchema>,
+) {
+  const { hash } = args;
+  logToFile(`Getting behaviour summary for ${hash}`);
+  const result = await queryVirusTotal(`/files/${hash}/behaviour_summary`);
+  return {
+    content: [formatBehaviourSummary(hash, result.data)],
   };
 }

--- a/src/handlers/file.ts
+++ b/src/handlers/file.ts
@@ -1,101 +1,61 @@
 import { z } from 'zod';
-import { queryVirusTotal } from '../utils/api.js';
+import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
 import { formatFileResults } from '../formatters/index.js';
 import { GetFileReportArgsSchema, GetFileRelationshipArgsSchema } from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
-import { RelationshipData } from '../types/virustotal.js';
 
-// Default relationships to fetch
 const DEFAULT_RELATIONSHIPS = [
-    'behaviours',
-    'contacted_domains',
-    'contacted_ips',
-    'contacted_urls',
-    'dropped_files',
-    'execution_parents',
-    'embedded_domains',
-    'embedded_ips',
-    'embedded_urls',
-    'itw_domains',
-    'itw_ips',
-    'itw_urls',
-    'related_threat_actors',
-    'similar_files'
+  'behaviours',
+  'contacted_domains',
+  'contacted_ips',
+  'contacted_urls',
+  'dropped_files',
+  'execution_parents',
+  'embedded_domains',
+  'embedded_ips',
+  'embedded_urls',
+  'itw_domains',
+  'itw_ips',
+  'itw_urls',
+  'related_threat_actors',
+  'similar_files',
 ] as const;
 
 export async function handleGetFileReport(args: z.infer<typeof GetFileReportArgsSchema>) {
-  const hash = args.hash;
-
-  // First get the basic file report
-  logToFile('Getting file report...');
-  const basicReport = await queryVirusTotal(
-    `/files/${hash}`
+  const { hash } = args;
+  logToFile('Getting file report with relationships...');
+  const report = await queryVirusTotalWithRelationships(
+    `/files/${hash}`,
+    DEFAULT_RELATIONSHIPS,
   );
-
-  // Then get full data for specified relationships
-  const relationshipData: Record<string, RelationshipData> = {};
-  
-  for (const relType of DEFAULT_RELATIONSHIPS) {
-    logToFile(`Getting full data for ${relType}...`);
-    try {
-      const response = await queryVirusTotal(
-        `/files/${hash}/${relType}`,
-        'get'
-      );
-
-      // Format the relationship data
-      if (Array.isArray(response.data)) {
-        relationshipData[relType] = {
-          data: response.data,
-          meta: response.meta
-        };
-      } else if (response.data) {
-        relationshipData[relType] = {
-          data: response.data,
-          meta: response.meta
-        };
-      }
-    } catch (error) {
-      logToFile(`Error fetching ${relType} data: ${error}`);
-      // Continue with other relationships even if one fails
-    }
-  }
-
-  // Combine the basic report with relationships
-  const combinedData = {
-    ...basicReport.data,
-    relationships: relationshipData
-  };
-
   return {
-    content: [
-      formatFileResults(combinedData)
-    ],
+    content: [formatFileResults(report.data)],
   };
 }
 
 export async function handleGetFileRelationship(args: z.infer<typeof GetFileRelationshipArgsSchema>) {
   const { hash, relationship, limit, cursor } = args;
-  
+
   const params: Record<string, string | number> = { limit };
   if (cursor) params.cursor = cursor;
-  
+
   const result = await queryVirusTotal(
     `/files/${hash}/${relationship}`,
-    'get'
+    'get',
+    undefined,
+    params,
   );
 
   return {
     content: [
       formatFileResults({
-        ...result.data,
         relationships: {
           [relationship]: {
             data: result.data,
-            meta: result.meta
-          }
-        }
-      })
+            meta: result.meta,
+          },
+        },
+      }),
     ],
   };
 }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,3 +2,5 @@ export * from './url.js';
 export * from './file.js';
 export * from './ip.js';
 export * from './domain.js';
+export * from './search.js';
+export * from './collection.js';

--- a/src/handlers/ip.ts
+++ b/src/handlers/ip.ts
@@ -1,94 +1,54 @@
 import { z } from 'zod';
-import { queryVirusTotal } from '../utils/api.js';
+import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
 import { formatIpResults } from '../formatters/index.js';
 import { GetIpReportArgsSchema, GetIpRelationshipArgsSchema } from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
-import { RelationshipData } from '../types/virustotal.js';
 
-// Default relationships to fetch
 const DEFAULT_RELATIONSHIPS = [
-    'communicating_files',
-    'downloaded_files',
-    'historical_ssl_certificates',
-    'resolutions',
-    'related_threat_actors',
-    'urls'
+  'communicating_files',
+  'downloaded_files',
+  'historical_ssl_certificates',
+  'resolutions',
+  'related_threat_actors',
+  'urls',
 ] as const;
 
 export async function handleGetIpReport(args: z.infer<typeof GetIpReportArgsSchema>) {
-  const ip = args.ip;
-
-  // First get the basic IP report
-  logToFile('Getting IP report...');
-  const basicReport = await queryVirusTotal(
-    `/ip_addresses/${ip}`
+  const { ip } = args;
+  logToFile('Getting IP report with relationships...');
+  const report = await queryVirusTotalWithRelationships(
+    `/ip_addresses/${ip}`,
+    DEFAULT_RELATIONSHIPS,
   );
-
-  // Then get full data for specified relationships
-  const relationshipData: Record<string, RelationshipData> = {};
-  
-  for (const relType of DEFAULT_RELATIONSHIPS) {
-    logToFile(`Getting full data for ${relType}...`);
-    try {
-      const response = await queryVirusTotal(
-        `/ip_addresses/${ip}/${relType}`,
-        'get'
-      );
-
-      // Format the relationship data
-      if (Array.isArray(response.data)) {
-        relationshipData[relType] = {
-          data: response.data,
-          meta: response.meta
-        };
-      } else if (response.data) {
-        relationshipData[relType] = {
-          data: response.data,
-          meta: response.meta
-        };
-      }
-    } catch (error) {
-      logToFile(`Error fetching ${relType} data: ${error}`);
-      // Continue with other relationships even if one fails
-    }
-  }
-
-  // Combine the basic report with detailed relationships
-  const combinedData = {
-    ...basicReport.data,
-    relationships: relationshipData
-  };
-
   return {
-    content: [
-      formatIpResults(combinedData)
-    ],
+    content: [formatIpResults(report.data)],
   };
 }
 
 export async function handleGetIpRelationship(args: z.infer<typeof GetIpRelationshipArgsSchema>) {
   const { ip, relationship, limit, cursor } = args;
-  
+
   const params: Record<string, string | number> = { limit };
   if (cursor) params.cursor = cursor;
-  
+
   const result = await queryVirusTotal(
     `/ip_addresses/${ip}/${relationship}`,
-    'get'
+    'get',
+    undefined,
+    params,
   );
 
   return {
     content: [
       formatIpResults({
         id: ip,
-        attributes: result.data.attributes,
         relationships: {
           [relationship]: {
             data: result.data,
-            meta: result.meta
-          }
-        }
-      })
+            meta: result.meta,
+          },
+        },
+      }),
     ],
   };
 }

--- a/src/handlers/search.ts
+++ b/src/handlers/search.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { queryVirusTotal } from '../utils/api.js';
+import { formatSearchResults } from '../formatters/index.js';
+import { SearchArgsSchema } from '../schemas/index.js';
+import { logToFile } from '../utils/logging.js';
+
+export async function handleSearch(args: z.infer<typeof SearchArgsSchema>) {
+  const { query, limit, cursor } = args;
+
+  const params: Record<string, string | number> = { query, limit };
+  if (cursor) params.cursor = cursor;
+
+  logToFile(`Searching VT corpus: ${query}`);
+  const result = await queryVirusTotal('/search', 'get', undefined, params);
+
+  return {
+    content: [formatSearchResults(query, result.data, result.meta)],
+  };
+}

--- a/src/handlers/url.ts
+++ b/src/handlers/url.ts
@@ -1,91 +1,71 @@
 import { z } from 'zod';
-import { queryVirusTotal, encodeUrlForVt } from '../utils/api.js';
+import {
+  queryVirusTotal,
+  queryVirusTotalWithRelationships,
+  encodeUrlForVt,
+  VirusTotalApiError,
+} from '../utils/api.js';
 import { formatUrlScanResults } from '../formatters/index.js';
 import { GetUrlReportArgsSchema, GetUrlRelationshipArgsSchema } from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
-import { RelationshipData } from '../types/virustotal.js';
 
-// Default relationships to fetch
 const DEFAULT_RELATIONSHIPS = [
-    'communicating_files',
-    'contacted_domains',
-    'contacted_ips',
-    'downloaded_files',
-    'redirects_to',
-    'redirecting_urls',
-    'related_threat_actors'
+  'communicating_files',
+  'contacted_domains',
+  'contacted_ips',
+  'downloaded_files',
+  'redirects_to',
+  'redirecting_urls',
+  'related_threat_actors',
 ] as const;
 
+const POLL_INTERVAL_MS = 5000;
+const POLL_MAX_ATTEMPTS = 12; // ~60s total
+
+async function waitForAnalysis(analysisId: string): Promise<void> {
+  for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
+    const response = await queryVirusTotal(`/analyses/${analysisId}`);
+    const status = response?.data?.attributes?.status;
+    if (status === 'completed') return;
+    logToFile(`Analysis ${analysisId} status=${status}, retrying in ${POLL_INTERVAL_MS}ms`);
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `URL analysis ${analysisId} did not complete within ${(POLL_MAX_ATTEMPTS * POLL_INTERVAL_MS) / 1000}s`,
+  );
+}
+
 export async function handleGetUrlReport(args: z.infer<typeof GetUrlReportArgsSchema>) {
-  const url = args.url;
+  const { url } = args;
   const encodedUrl = encodeUrlForVt(url);
 
-  // First submit URL for scanning
-  logToFile(`Scanning URL: ${url}`);
-  const scanResponse = await queryVirusTotal(
-    '/urls',
-    'post',
-    new URLSearchParams({ url })
-  );
-  
-  const analysisId = scanResponse.data.id;
-  logToFile(`Analysis ID: ${analysisId}`);
-  
-  // Wait for analysis to complete
-  await new Promise(resolve => setTimeout(resolve, 3000));
-  
-  // Get analysis results
-  const analysisResponse = await queryVirusTotal(
-    `/analyses/${analysisId}`
-  );
-
-  // Then get full data for specified relationships
-  const relationshipData: Record<string, RelationshipData> = {};
-  
-  for (const relType of DEFAULT_RELATIONSHIPS) {
-    logToFile(`Fetching ${relType}`);
-    try {
-      const response = await queryVirusTotal(
-        `/urls/${encodedUrl}/${relType}`,
-        'get'
+  let report;
+  try {
+    logToFile(`Fetching cached URL report for ${url}`);
+    report = await queryVirusTotalWithRelationships(`/urls/${encodedUrl}`, DEFAULT_RELATIONSHIPS);
+  } catch (error) {
+    if (error instanceof VirusTotalApiError && error.status === 404) {
+      logToFile(`No cached report for ${url}; submitting for scan`);
+      const scanResponse = await queryVirusTotal(
+        '/urls',
+        'post',
+        new URLSearchParams({ url }),
       );
-
-      // Only log relationship metadata
-      logToFile(`${relType} count: ${
-        Array.isArray(response.data) ? response.data.length : 
-        response.data ? '1' : '0'
-      }`);
-
-      // Format the relationship data
-      if (Array.isArray(response.data)) {
-        relationshipData[relType] = {
-          data: response.data,
-          meta: response.meta
-        };
-      } else if (response.data) {
-        relationshipData[relType] = {
-          data: response.data,
-          meta: response.meta
-        };
-      }
-    } catch (error) {
-      logToFile(`Failed to fetch ${relType}`);
-      // Continue with other relationships even if one fails
+      await waitForAnalysis(scanResponse.data.id);
+      report = await queryVirusTotalWithRelationships(`/urls/${encodedUrl}`, DEFAULT_RELATIONSHIPS);
+    } else {
+      throw error;
     }
   }
 
-  // Combine the analysis results with relationships
-  const combinedData = {
-    id: analysisId,
-    url: url,
-    attributes: analysisResponse.data.attributes,
-    scan_date: new Date().toISOString(),
-    relationships: relationshipData
-  };
-
   return {
     content: [
-      formatUrlScanResults(combinedData)
+      formatUrlScanResults({
+        id: report.data?.id,
+        url,
+        attributes: report.data?.attributes,
+        relationships: report.data?.relationships,
+      }),
     ],
   };
 }
@@ -93,28 +73,29 @@ export async function handleGetUrlReport(args: z.infer<typeof GetUrlReportArgsSc
 export async function handleGetUrlRelationship(args: z.infer<typeof GetUrlRelationshipArgsSchema>) {
   const { url, relationship, limit, cursor } = args;
   const encodedUrl = encodeUrlForVt(url);
-  
+
   const params: Record<string, string | number> = { limit };
   if (cursor) params.cursor = cursor;
-  
+
   logToFile(`Fetching ${relationship} for URL: ${url}`);
   const result = await queryVirusTotal(
     `/urls/${encodedUrl}/${relationship}`,
-    'get'
+    'get',
+    undefined,
+    params,
   );
 
   return {
     content: [
       formatUrlScanResults({
-        url: url,
-        attributes: result.data.attributes,
+        url,
         relationships: {
           [relationship]: {
             data: result.data,
-            meta: result.meta
-          }
-        }
-      })
+            meta: result.meta,
+          },
+        },
+      }),
     ],
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,18 +12,26 @@ import {
   GetUrlRelationshipArgsSchema,
   GetFileReportArgsSchema,
   GetFileRelationshipArgsSchema,
+  GetFileBehaviourSummaryArgsSchema,
   GetIpReportArgsSchema,
   GetIpRelationshipArgsSchema,
   GetDomainReportArgsSchema,
+  GetDomainRelationshipArgsSchema,
+  SearchArgsSchema,
+  GetCollectionArgsSchema,
 } from './schemas/index.js';
 import {
   handleGetUrlReport,
   handleGetUrlRelationship,
   handleGetFileReport,
   handleGetFileRelationship,
+  handleGetFileBehaviourSummary,
   handleGetIpReport,
   handleGetIpRelationship,
   handleGetDomainReport,
+  handleGetDomainRelationship,
+  handleSearch,
+  handleGetCollection,
 } from './handlers/index.js';
 
 dotenv.config();
@@ -102,6 +110,37 @@ server.addTool({
     'Get a comprehensive domain analysis report including DNS records, WHOIS data, and key relationships (SSL certificates, subdomains, historical data). Optionally specify which relationships to include in the report. Returns both the basic analysis and relationship data.',
   parameters: GetDomainReportArgsSchema,
   execute: async (args) => handleGetDomainReport(args),
+});
+
+server.addTool({
+  name: 'get_domain_relationship',
+  description: `Query a specific relationship type for a domain with pagination support. Choose from ${RELATIONSHIPS.domain.length} relationship types including subdomains, resolutions, SSL certificates, WHOIS history, and threat actors. Useful for detailed investigation of specific relationship types.`,
+  parameters: GetDomainRelationshipArgsSchema,
+  execute: async (args) => handleGetDomainRelationship(args),
+});
+
+server.addTool({
+  name: 'search_vt',
+  description:
+    'Search the VirusTotal corpus for files, URLs, domains, IPs, or comments matching a query. Accepts plain IOCs (hash, URL, domain, IP), free text against comments, or VTI-style search modifiers like "type:peexe size:90kb+ tag:signed positives:5+". Paginated via cursor.',
+  parameters: SearchArgsSchema,
+  execute: async (args) => handleSearch(args),
+});
+
+server.addTool({
+  name: 'get_file_behaviour_summary',
+  description:
+    'Get a consolidated sandbox behaviour summary for a file (MD5/SHA-1/SHA-256), merged across every sandbox that analyzed it. Returns processes, files, registry, network activity, MITRE ATT&CK techniques, IDS alerts, and signature matches in a single view — far more useful than iterating individual behaviour reports.',
+  parameters: GetFileBehaviourSummaryArgsSchema,
+  execute: async (args) => handleGetFileBehaviourSummary(args),
+});
+
+server.addTool({
+  name: 'get_collection',
+  description:
+    'Retrieve a VirusTotal collection by ID. Collections represent threat actors, malware families, campaigns, intel reports, and curated IOC sets — often referenced from the related_threat_actors and collections relationships on other tools. Optionally include relationships (e.g. files, urls, domains, ip_addresses, references, threat_actors, attack_techniques) to fetch member IOCs in the same call.',
+  parameters: GetCollectionArgsSchema,
+  execute: async (args) => handleGetCollection(args),
 });
 
 process.on('uncaughtException', (error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 
-import { FastMCP } from "fastmcp";
-import dotenv from "dotenv";
+import { FastMCP } from 'fastmcp';
+import dotenv from 'dotenv';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { logToFile } from './utils/logging.js';
+import { initVirusTotalClient, RELATIONSHIPS } from './utils/api.js';
 import {
   GetUrlReportArgsSchema,
   GetUrlRelationshipArgsSchema,
@@ -24,9 +28,14 @@ import {
 
 dotenv.config();
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf8'),
+) as { version: string };
+
 const server = new FastMCP({
-  name: "virustotal-mcp",
-  version: "1.0.0",
+  name: 'virustotal-mcp',
+  version: pkg.version as `${number}.${number}.${number}`,
   instructions: `VirusTotal Analysis Server
 
 This server provides comprehensive security analysis tools using the VirusTotal API. Each analysis tool automatically fetches relevant relationship data (e.g., contacted domains, downloaded files) along with the basic report.
@@ -43,55 +52,58 @@ All tools return formatted results with clear categorization and relationship da
 });
 
 server.addTool({
-  name: "get_url_report",
-  description: "Get a comprehensive URL analysis report including security scan results and key relationships (communicating files, contacted domains/IPs, downloaded files, redirects, threat actors). Returns both the basic security analysis and automatically fetched relationship data.",
+  name: 'get_url_report',
+  description:
+    'Get a comprehensive URL analysis report including security scan results and key relationships (communicating files, contacted domains/IPs, downloaded files, redirects, threat actors). Returns the cached VirusTotal report when available, or submits the URL for scanning and waits for results.',
   parameters: GetUrlReportArgsSchema,
   execute: async (args) => handleGetUrlReport(args),
 });
 
 server.addTool({
-  name: "get_url_relationship",
-  description: "Query a specific relationship type for a URL with pagination support. Choose from 17 relationship types including analyses, communicating files, contacted domains/IPs, downloaded files, graphs, referrers, redirects, and threat actors. Useful for detailed investigation of specific relationship types.",
+  name: 'get_url_relationship',
+  description: `Query a specific relationship type for a URL with pagination support. Choose from ${RELATIONSHIPS.url.length} relationship types. Useful for detailed investigation of specific relationship types.`,
   parameters: GetUrlRelationshipArgsSchema,
   execute: async (args) => handleGetUrlRelationship(args),
 });
 
 server.addTool({
-  name: "get_file_report",
-  description: "Get a comprehensive file analysis report using its hash (MD5/SHA-1/SHA-256). Includes detection results, file properties, and key relationships (behaviors, dropped files, network connections, embedded content, threat actors). Returns both the basic analysis and automatically fetched relationship data.",
+  name: 'get_file_report',
+  description:
+    'Get a comprehensive file analysis report using its hash (MD5/SHA-1/SHA-256). Includes detection results, file properties, and key relationships (behaviors, dropped files, network connections, embedded content, threat actors). Returns both the basic analysis and automatically fetched relationship data.',
   parameters: GetFileReportArgsSchema,
   execute: async (args) => handleGetFileReport(args),
 });
 
 server.addTool({
-  name: "get_file_relationship",
-  description: "Query a specific relationship type for a file with pagination support. Choose from 41 relationship types including behaviors, network connections, dropped files, embedded content, execution chains, and threat actors. Useful for detailed investigation of specific relationship types.",
+  name: 'get_file_relationship',
+  description: `Query a specific relationship type for a file with pagination support. Choose from ${RELATIONSHIPS.file.length} relationship types including behaviors, network connections, dropped files, embedded content, execution chains, and threat actors. Useful for detailed investigation of specific relationship types.`,
   parameters: GetFileRelationshipArgsSchema,
   execute: async (args) => handleGetFileRelationship(args),
 });
 
 server.addTool({
-  name: "get_ip_report",
-  description: "Get a comprehensive IP address analysis report including geolocation, reputation data, and key relationships (communicating files, historical certificates/WHOIS, resolutions). Returns both the basic analysis and automatically fetched relationship data.",
+  name: 'get_ip_report',
+  description:
+    'Get a comprehensive IP address analysis report including geolocation, reputation data, and key relationships (communicating files, historical certificates/WHOIS, resolutions). Returns both the basic analysis and automatically fetched relationship data.',
   parameters: GetIpReportArgsSchema,
   execute: async (args) => handleGetIpReport(args),
 });
 
 server.addTool({
-  name: "get_ip_relationship",
-  description: "Query a specific relationship type for an IP address with pagination support. Choose from 12 relationship types including communicating files, historical SSL certificates, WHOIS records, resolutions, and threat actors. Useful for detailed investigation of specific relationship types.",
+  name: 'get_ip_relationship',
+  description: `Query a specific relationship type for an IP address with pagination support. Choose from ${RELATIONSHIPS.ip.length} relationship types including communicating files, historical SSL certificates, WHOIS records, resolutions, and threat actors. Useful for detailed investigation of specific relationship types.`,
   parameters: GetIpRelationshipArgsSchema,
   execute: async (args) => handleGetIpRelationship(args),
 });
 
 server.addTool({
-  name: "get_domain_report",
-  description: "Get a comprehensive domain analysis report including DNS records, WHOIS data, and key relationships (SSL certificates, subdomains, historical data). Optionally specify which relationships to include in the report. Returns both the basic analysis and relationship data.",
+  name: 'get_domain_report',
+  description:
+    'Get a comprehensive domain analysis report including DNS records, WHOIS data, and key relationships (SSL certificates, subdomains, historical data). Optionally specify which relationships to include in the report. Returns both the basic analysis and relationship data.',
   parameters: GetDomainReportArgsSchema,
   execute: async (args) => handleGetDomainReport(args),
 });
 
-// Handle process events
 process.on('uncaughtException', (error) => {
   logToFile(`Uncaught exception: ${error.message}`);
   process.exit(1);
@@ -99,33 +111,28 @@ process.on('uncaughtException', (error) => {
 
 process.on('unhandledRejection', (reason) => {
   logToFile(`Unhandled rejection: ${reason}`);
+  process.exit(1);
 });
 
-// Start the server
 async function main() {
-  const transport = process.env.MCP_TRANSPORT || "stdio";
+  initVirusTotalClient();
 
+  const transport = process.env.MCP_TRANSPORT || 'stdio';
   logToFile(`Starting VirusTotal MCP Server (transport: ${transport})...`);
 
-  if (transport === "httpStream") {
-    const port = parseInt(process.env.MCP_PORT || "3000", 10);
-    const endpoint = (process.env.MCP_ENDPOINT || "/mcp") as `/${string}`;
+  if (transport === 'httpStream') {
+    const port = parseInt(process.env.MCP_PORT || '3000', 10);
+    const endpoint = (process.env.MCP_ENDPOINT || '/mcp') as `/${string}`;
 
     await server.start({
-      transportType: "httpStream",
-      httpStream: {
-        port,
-        endpoint,
-      },
+      transportType: 'httpStream',
+      httpStream: { port, endpoint },
     });
 
     logToFile(`VirusTotal MCP Server listening on port ${port} at ${endpoint}`);
   } else {
-    await server.start({
-      transportType: "stdio",
-    });
-
-    logToFile("VirusTotal MCP Server is running on stdio.");
+    await server.start({ transportType: 'stdio' });
+    logToFile('VirusTotal MCP Server is running on stdio.');
   }
 }
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -64,3 +64,30 @@ export const GetDomainRelationshipArgsSchema = z.object({
     .describe('Domain name to analyze'),
   relationship: z.enum(RELATIONSHIPS.domain).describe('Type of relationship to query'),
 }).merge(PaginationSchema);
+
+export const SearchArgsSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe('Search query. Accepts file hashes, URLs, domains, IPs, comments, or VTI-style search modifiers (e.g. "type:peexe size:90kb+ tag:signed")'),
+  limit: z.number().min(1).max(300).optional().default(20),
+  cursor: z.string().optional(),
+});
+
+export const GetFileBehaviourSummaryArgsSchema = z.object({
+  hash: z
+    .string()
+    .regex(/^[a-fA-F0-9]{32,64}$/, 'Must be a valid MD5, SHA-1, or SHA-256 hash')
+    .describe('MD5, SHA-1 or SHA-256 hash of the file'),
+});
+
+export const GetCollectionArgsSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .describe('Collection ID (e.g. a threat-actor, malware family, campaign, or report identifier returned from a relationship lookup)'),
+  relationships: z
+    .array(z.string())
+    .optional()
+    .describe('Optional list of relationships to include (e.g. ["files", "urls", "domains", "ip_addresses", "references", "threat_actors", "attack_techniques"])'),
+});

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,5 @@
-import { z } from "zod";
+import { z } from 'zod';
+import { RELATIONSHIPS } from '../utils/api.js';
 
 // Common Schema for Pagination
 export const PaginationSchema = z.object({
@@ -8,106 +9,58 @@ export const PaginationSchema = z.object({
 
 // Tool Schemas
 export const GetUrlReportArgsSchema = z.object({
-  url: z.string().url("Must be a valid URL").describe("The URL to analyze"),
+  url: z.string().url('Must be a valid URL').describe('The URL to analyze'),
 });
 
 export const GetUrlRelationshipArgsSchema = z.object({
-  url: z.string().url("Must be a valid URL").describe("The URL to get relationships for"),
-  relationship: z.enum([
-    "analyses", "comments", "communicating_files", "contacted_domains", 
-    "contacted_ips", "downloaded_files", "graphs", "last_serving_ip_address",
-    "network_location", "referrer_files", "referrer_urls", "redirecting_urls",
-    "redirects_to", "related_comments", "related_references", "related_threat_actors",
-    "submissions"
-  ]).describe("Type of relationship to query"),
+  url: z.string().url('Must be a valid URL').describe('The URL to get relationships for'),
+  relationship: z.enum(RELATIONSHIPS.url).describe('Type of relationship to query'),
 }).merge(PaginationSchema);
 
 export const GetFileReportArgsSchema = z.object({
   hash: z
     .string()
-    .regex(/^[a-fA-F0-9]{32,64}$/, "Must be a valid MD5, SHA-1, or SHA-256 hash")
-    .describe("MD5, SHA-1 or SHA-256 hash of the file"),
+    .regex(/^[a-fA-F0-9]{32,64}$/, 'Must be a valid MD5, SHA-1, or SHA-256 hash')
+    .describe('MD5, SHA-1 or SHA-256 hash of the file'),
 });
 
 export const GetFileRelationshipArgsSchema = z.object({
   hash: z
     .string()
-    .regex(/^[a-fA-F0-9]{32,64}$/, "Must be a valid MD5, SHA-1, or SHA-256 hash")
-    .describe("MD5, SHA-1 or SHA-256 hash of the file"),
-  relationship: z.enum([
-    "analyses", "behaviours", "bundled_files", "carbonblack_children",
-    "carbonblack_parents", "ciphered_bundled_files", "ciphered_parents",
-    "clues", "collections", "comments", "compressed_parents", "contacted_domains",
-    "contacted_ips", "contacted_urls", "dropped_files", "email_attachments",
-    "email_parents", "embedded_domains", "embedded_ips", "embedded_urls",
-    "execution_parents", "graphs", "itw_domains", "itw_ips", "itw_urls",
-    "memory_pattern_domains", "memory_pattern_ips", "memory_pattern_urls",
-    "overlay_children", "overlay_parents", "pcap_children", "pcap_parents",
-    "pe_resource_children", "pe_resource_parents", "related_references",
-    "related_threat_actors", "similar_files", "submissions", "screenshots",
-    "urls_for_embedded_js", "votes"
-  ]).describe("Type of relationship to query"),
+    .regex(/^[a-fA-F0-9]{32,64}$/, 'Must be a valid MD5, SHA-1, or SHA-256 hash')
+    .describe('MD5, SHA-1 or SHA-256 hash of the file'),
+  relationship: z.enum(RELATIONSHIPS.file).describe('Type of relationship to query'),
 }).merge(PaginationSchema);
 
 export const GetIpReportArgsSchema = z.object({
   ip: z
     .string()
-    .ip("Must be a valid IP address")
-    .describe("IP address to analyze"),
+    .ip('Must be a valid IP address')
+    .describe('IP address to analyze'),
 });
 
 export const GetIpRelationshipArgsSchema = z.object({
   ip: z
     .string()
-    .ip("Must be a valid IP address")
-    .describe("IP address to analyze"),
-  relationship: z.enum([
-    "comments", "communicating_files", "downloaded_files", "graphs",
-    "historical_ssl_certificates", "historical_whois", "related_comments",
-    "related_references", "related_threat_actors", "referrer_files",
-    "resolutions", "urls"
-  ]).describe("Type of relationship to query"),
+    .ip('Must be a valid IP address')
+    .describe('IP address to analyze'),
+  relationship: z.enum(RELATIONSHIPS.ip).describe('Type of relationship to query'),
 }).merge(PaginationSchema);
-
-// Define available domain relationships
-export const DomainRelationships = [
-  "caa_records",
-  "cname_records",
-  "comments",
-  "communicating_files",
-  "downloaded_files",
-  "historical_ssl_certificates",
-  "historical_whois",
-  "immediate_parent",
-  "mx_records",
-  "ns_records",
-  "parent",
-  "referrer_files",
-  "related_comments",
-  "related_references",
-  "related_threat_actors",
-  "resolutions",
-  "soa_records",
-  "siblings",
-  "subdomains",
-  "urls",
-  "user_votes"
-] as const;
 
 export const GetDomainReportArgsSchema = z.object({
   domain: z
     .string()
-    .regex(/^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/, "Must be a valid domain name")
-    .describe("Domain name to analyze"),
-  relationships: z.array(z.enum(DomainRelationships))
+    .regex(/^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/, 'Must be a valid domain name')
+    .describe('Domain name to analyze'),
+  relationships: z.array(z.enum(RELATIONSHIPS.domain))
     .optional()
-    .describe("Optional array of relationships to include in the report"),
+    .describe('Optional array of relationships to include in the report'),
 });
 
 export const GetDomainRelationshipArgsSchema = z.object({
   domain: z
     .string()
-    .regex(/^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/, "Must be a valid domain name")
-    .describe("Domain name to analyze"),
-  relationship: z.enum(DomainRelationships).describe("Type of relationship to query"),
+    .regex(/^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/, 'Must be a valid domain name')
+    .describe('Domain name to analyze'),
+  relationship: z.enum(RELATIONSHIPS.domain).describe('Type of relationship to query'),
 }).merge(PaginationSchema);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,114 +1,150 @@
-import { AxiosError } from 'axios';
-import axios from 'axios';
-import dotenv from 'dotenv';
+import axios, { AxiosError, AxiosInstance } from 'axios';
 import { logToFile } from './logging.js';
 
-dotenv.config();
-
-const API_KEY = process.env.VIRUSTOTAL_API_KEY;
-
-if (!API_KEY) {
-  throw new Error("VIRUSTOTAL_API_KEY environment variable is required");
+export class VirusTotalApiError extends Error {
+  constructor(message: string, public status?: number, public code?: string) {
+    super(message);
+    this.name = 'VirusTotalApiError';
+  }
 }
 
-export const axiosInstance = axios.create({
-  baseURL: 'https://www.virustotal.com/api/v3',
-  headers: {
-    'x-apikey': API_KEY,
-  },
-});
+let axiosInstance: AxiosInstance | null = null;
 
-export interface VirusTotalErrorResponse {
-  error?: {
-    message?: string;
-  };
+export function initVirusTotalClient(): void {
+  const apiKey = process.env.VIRUSTOTAL_API_KEY;
+  if (!apiKey) {
+    throw new Error('VIRUSTOTAL_API_KEY environment variable is required');
+  }
+  axiosInstance = axios.create({
+    baseURL: 'https://www.virustotal.com/api/v3',
+    headers: { 'x-apikey': apiKey },
+  });
 }
 
-// Helper Function to Query VirusTotal API
+function getClient(): AxiosInstance {
+  if (!axiosInstance) initVirusTotalClient();
+  return axiosInstance!;
+}
+
+interface VirusTotalErrorResponse {
+  error?: { code?: string; message?: string };
+}
+
 export async function queryVirusTotal(
   endpoint: string,
   method: 'get' | 'post' = 'get',
   data?: any,
   params?: Record<string, string | number | boolean>
 ) {
-  if (!endpoint) {
-    throw new Error('Endpoint is required');
-  }
+  if (!endpoint) throw new Error('Endpoint is required');
+  const client = getClient();
   try {
-    // Log minimal request details
     logToFile(`${method.toUpperCase()} ${endpoint}`);
-    
-    if (params) {
-      // Log only param keys, not values
-      logToFile(`Request params: ${Object.keys(params).join(', ')}`);
-    }
-    
-    const response = method === 'get' 
-      ? await axiosInstance.get(endpoint, { params })
-      : await axiosInstance.post(endpoint, data, { params });
+    if (params) logToFile(`Request params: ${Object.keys(params).join(', ')}`);
 
-    // Log minimal response info
+    const response = method === 'get'
+      ? await client.get(endpoint, { params })
+      : await client.post(endpoint, data, { params });
+
     logToFile(`Response status: ${response.status}`);
-    
     return response.data;
   } catch (error: any) {
     if (axios.isAxiosError(error)) {
       const axiosError = error as AxiosError<VirusTotalErrorResponse>;
-      // Log only essential error info
-      logToFile(`API Error: ${axiosError.response?.status} - ${
-        axiosError.response?.data?.error?.message || axiosError.message
-      }`);
-      throw new Error(`VirusTotal API error: ${
-        axiosError.response?.data?.error?.message || axiosError.message
-      }`);
+      const status = axiosError.response?.status;
+      const code = axiosError.response?.data?.error?.code;
+      const message = axiosError.response?.data?.error?.message || axiosError.message;
+      logToFile(`API Error: ${status} - ${message}`);
+      throw new VirusTotalApiError(`VirusTotal API error: ${message}`, status, code);
     }
     throw error;
   }
 }
 
-// Helper function to encode URL for VirusTotal API
 export function encodeUrlForVt(url: string): string {
   return Buffer.from(url).toString('base64url');
 }
 
-// Helper function to get all available relationships for each type
+// Canonical relationship lists per VirusTotal API v3 docs
+// (https://virustotal.readme.io/llms.txt — verified May 2026).
+// Single source of truth: schemas/index.ts derives Zod enums from this.
 export const RELATIONSHIPS = {
   url: [
-    "analyses", "comments", "communicating_files", "contacted_domains", 
-    "contacted_ips", "downloaded_files", "graphs", "last_serving_ip_address",
-    "network_location", "referrer_files", "referrer_urls", "redirecting_urls",
-    "redirects_to", "related_comments", "related_references", "related_threat_actors",
-    "submissions"
+    'analyses', 'collections', 'comments', 'communicating_files',
+    'contacted_domains', 'contacted_ips', 'downloaded_files',
+    'embedded_js_files', 'graphs', 'last_serving_ip_address',
+    'network_location', 'referrer_files', 'referrer_urls',
+    'redirecting_urls', 'redirects_to', 'related_comments',
+    'related_references', 'related_threat_actors', 'submissions',
+    'urls_related_by_tracker_id', 'user_votes', 'votes',
   ],
   file: [
-    "analyses", "behaviours", "bundled_files", "carbonblack_children",
-    "carbonblack_parents", "ciphered_bundled_files", "ciphered_parents",
-    "clues", "collections", "comments", "compressed_parents", "contacted_domains",
-    "contacted_ips", "contacted_urls", "dropped_files", "email_attachments",
-    "email_parents", "embedded_domains", "embedded_ips", "embedded_urls",
-    "execution_parents", "graphs", "itw_domains", "itw_ips", "itw_urls",
-    "memory_pattern_domains", "memory_pattern_ips", "memory_pattern_urls",
-    "overlay_children", "overlay_parents", "pcap_children", "pcap_parents",
-    "pe_resource_children", "pe_resource_parents", "related_references",
-    "related_threat_actors", "similar_files", "submissions", "screenshots",
-    "urls_for_embedded_js", "votes"
+    'analyses', 'behaviours', 'bundled_files', 'carbonblack_children',
+    'carbonblack_parents', 'ciphered_bundled_files', 'ciphered_parents',
+    'collections', 'comments', 'compressed_parents', 'contacted_domains',
+    'contacted_ips', 'contacted_urls', 'dropped_files', 'email_attachments',
+    'email_parents', 'embedded_domains', 'embedded_ips', 'embedded_urls',
+    'execution_parents', 'graphs', 'itw_domains', 'itw_ips', 'itw_urls',
+    'memory_pattern_domains', 'memory_pattern_ips', 'memory_pattern_urls',
+    'overlay_children', 'overlay_parents', 'pcap_children', 'pcap_parents',
+    'pe_resource_children', 'pe_resource_parents', 'related_references',
+    'related_threat_actors', 'similar_files', 'submissions', 'screenshots',
+    'urls_for_embedded_js', 'votes',
   ],
   ip: [
-    "comments", "communicating_files", "downloaded_files", "graphs",
-    "historical_ssl_certificates", "historical_whois", "related_comments",
-    "related_references", "related_threat_actors", "referrer_files",
-    "resolutions", "urls"
+    'collections', 'comments', 'communicating_files', 'downloaded_files',
+    'graphs', 'historical_ssl_certificates', 'historical_whois',
+    'related_comments', 'related_references', 'related_threat_actors',
+    'referrer_files', 'resolutions', 'urls', 'user_votes', 'votes',
   ],
   domain: [
-    "caa_records", "cname_records", "comments", "communicating_files",
-    "downloaded_files", "graphs", "historical_ssl_certificates", "historical_whois",
-    "immediate_parent", "mx_records", "ns_records", "parent", "referrer_files",
-    "related_comments", "related_references", "related_threat_actors",
-    "resolutions", "soa_records", "siblings", "subdomains", "urls", "user_votes"
-  ]
+    'caa_records', 'cname_records', 'collections', 'comments',
+    'communicating_files', 'downloaded_files', 'graphs',
+    'historical_ssl_certificates', 'historical_whois', 'immediate_parent',
+    'mx_records', 'ns_records', 'parent', 'referrer_files',
+    'related_comments', 'related_references', 'related_threat_actors',
+    'resolutions', 'soa_records', 'siblings', 'subdomains', 'urls',
+    'user_votes', 'votes',
+  ],
 } as const;
 
-// Helper function to get relationships query parameter
-export function getRelationshipsParam(type: keyof typeof RELATIONSHIPS): string {
-  return RELATIONSHIPS[type].join(',');
+// VT caps the relationships you can request in a single call; batch to be safe.
+const RELATIONSHIPS_PER_REQUEST = 8;
+
+// Fetch an object + a set of relationship summaries in as few calls as
+// possible by using VT's `?relationships=a,b,c` query, batched.
+export async function queryVirusTotalWithRelationships(
+  baseEndpoint: string,
+  relationships: readonly string[],
+): Promise<any> {
+  if (relationships.length === 0) {
+    return queryVirusTotal(baseEndpoint);
+  }
+
+  const batches: string[][] = [];
+  for (let i = 0; i < relationships.length; i += RELATIONSHIPS_PER_REQUEST) {
+    batches.push([...relationships.slice(i, i + RELATIONSHIPS_PER_REQUEST)]);
+  }
+
+  const responses = await Promise.all(
+    batches.map((batch) =>
+      queryVirusTotal(baseEndpoint, 'get', undefined, {
+        relationships: batch.join(','),
+      }),
+    ),
+  );
+
+  const base = responses[0];
+  const mergedRelationships = responses.reduce<Record<string, any>>(
+    (acc, r) => ({ ...acc, ...(r?.data?.relationships || {}) }),
+    {},
+  );
+
+  return {
+    ...base,
+    data: {
+      ...base.data,
+      relationships: mergedRelationships,
+    },
+  };
 }

--- a/tests/formatters.test.mjs
+++ b/tests/formatters.test.mjs
@@ -1,0 +1,185 @@
+// Unit tests for the formatters. Run after `npm run build`.
+// Uses node:test so we avoid adding test-framework deps.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatSearchResults,
+  formatBehaviourSummary,
+  formatCollectionResults,
+  formatFileResults,
+  formatUrlScanResults,
+  formatIpResults,
+  formatDomainResults,
+  formatDetectionResults,
+  formatDateTime,
+} from '../build/formatters/index.js';
+
+// ---------- utilities ----------
+
+test('formatDateTime handles unix seconds, ISO strings, and null', () => {
+  assert.match(formatDateTime(1700000000), /2023|2024/);
+  assert.match(formatDateTime('2024-01-15T00:00:00Z'), /2024/);
+  assert.equal(formatDateTime(null), 'N/A');
+});
+
+test('formatDetectionResults handles empty stats and a real distribution', () => {
+  assert.match(formatDetectionResults({}), /No detection results available/);
+  const text = formatDetectionResults({ malicious: 3, suspicious: 1, harmless: 50, undetected: 20 });
+  assert.match(text, /Malicious: 3/);
+  assert.match(text, /Total Scans: 74/);
+});
+
+// ---------- search ----------
+
+test('formatSearchResults: empty results', () => {
+  const out = formatSearchResults('nothing-here', [], {});
+  assert.match(out.text, /Query: nothing-here/);
+  assert.match(out.text, /No matching objects found/);
+});
+
+test('formatSearchResults: mixed file/url/domain/ip/comment items', () => {
+  const out = formatSearchResults('test', [
+    { type: 'file', id: 'abc', attributes: { meaningful_name: 'evil.exe', type_description: 'PE', sha256: 'abc', last_analysis_stats: { malicious: 5, harmless: 60, undetected: 5, suspicious: 0 } } },
+    { type: 'url', id: 'urlid', attributes: { url: 'https://bad.example', title: 'Bad' } },
+    { type: 'domain', id: 'bad.example' },
+    { type: 'ip_address', id: '1.2.3.4', attributes: { as_owner: 'EvilCo', country: 'XX' } },
+    { type: 'comment', id: 'cm1', attributes: { text: 'This file is malicious — see thread' } },
+  ], { cursor: 'next-cursor' });
+  assert.match(out.text, /file • evil.exe/);
+  assert.match(out.text, /url • https:\/\/bad.example/);
+  assert.match(out.text, /domain • bad.example/);
+  assert.match(out.text, /ip • 1.2.3.4/);
+  assert.match(out.text, /EvilCo \(XX\)/);
+  assert.match(out.text, /comment • cm1/);
+  assert.match(out.text, /cursor: next-cursor/);
+});
+
+// ---------- behaviour summary ----------
+
+test('formatBehaviourSummary: minimal/empty payload does not crash', () => {
+  const out = formatBehaviourSummary('deadbeef', {});
+  assert.match(out.text, /Sandbox Behaviour Summary/);
+  assert.match(out.text, /deadbeef/);
+});
+
+test('formatBehaviourSummary: full payload renders sections + proto field', () => {
+  const out = formatBehaviourSummary('h1', {
+    verdicts: ['malware'],
+    tags: ['persistence', 'ransom'],
+    mitre_attack_techniques: [
+      { id: 'T1059', signature_description: 'Command and Scripting Interpreter', severity: 'HIGH' },
+    ],
+    processes_created: ['cmd.exe /c whoami', 'powershell.exe -enc ...'],
+    files_dropped: [{ path: 'C:\\Users\\victim\\evil.exe', sha256: 'abc' }],
+    registry_keys_set: [{ key: 'HKLM\\Run\\Evil', value: 'C:\\evil.exe' }],
+    dns_lookups: [{ hostname: 'c2.example', resolved_ips: ['1.2.3.4'] }],
+    ids_results: [
+      {
+        rule_msg: 'C2 Beacon',
+        alert_severity: 'high',
+        alert_context: [{ proto: 'TCP', src_ip: '10.0.0.1', src_port: 4444, dest_ip: '1.2.3.4', dest_port: 443 }],
+      },
+    ],
+  });
+  assert.match(out.text, /Verdicts: malware/);
+  assert.match(out.text, /T1059 \[HIGH\]/);
+  assert.match(out.text, /cmd.exe \/c whoami/);
+  assert.match(out.text, /C:\\Users\\victim\\evil.exe \(abc\)/);
+  assert.match(out.text, /HKLM\\Run\\Evil = C:\\evil.exe/);
+  assert.match(out.text, /c2.example → 1.2.3.4/);
+  assert.match(out.text, /C2 Beacon \[high\]/);
+  assert.match(out.text, /TCP 10.0.0.1:4444 → 1.2.3.4:443/);
+});
+
+// ---------- collection ----------
+
+test('formatCollectionResults: threat-actor with counts and relationships', () => {
+  const out = formatCollectionResults({
+    type: 'collection',
+    id: 'threat-actor--example',
+    attributes: {
+      name: 'APT Example',
+      collection_type: 'threat-actor',
+      description: 'A well-known nation-state actor.',
+      aliases: ['Group X', 'Actor Y'],
+      tags: ['nation-state'],
+      threat_categories: ['espionage'],
+      motivations: ['intelligence-gathering'],
+      source_region: 'XX',
+      targeted_regions: ['US', 'EU'],
+      targeted_industries: ['finance', 'energy'],
+      files_count: 42,
+      urls_count: 7,
+      domains_count: 3,
+      ip_addresses_count: 5,
+      references_count: 12,
+      creation_date: 1700000000,
+      last_modification_date: 1710000000,
+    },
+    relationships: {
+      files: { data: [{ id: 'f1', attributes: { meaningful_name: 'sample.exe' } }, { id: 'f2', attributes: {} }], meta: { count: 2 } },
+    },
+  });
+  assert.match(out.text, /Collection: APT Example/);
+  assert.match(out.text, /threat-actor/);
+  assert.match(out.text, /Aliases: Group X, Actor Y/);
+  assert.match(out.text, /Files: 42/);
+  assert.match(out.text, /sample.exe/);
+});
+
+test('formatCollectionResults: minimal payload', () => {
+  const out = formatCollectionResults({ id: 'x', attributes: {} });
+  assert.match(out.text, /Collection: x/);
+});
+
+// ---------- file (the proto fix) ----------
+
+test('formatFileResults: behaviours relationship reads alert_context.proto (not .protocol)', () => {
+  const out = formatFileResults({
+    attributes: { sha256: 'h', md5: 'm', sha1: 's' },
+    relationships: {
+      behaviours: {
+        data: [{
+          id: 'b1',
+          attributes: {
+            sandbox_name: 'TestBox',
+            ids_results: [{
+              rule_msg: 'Beacon',
+              alert_context: { proto: 'UDP', src_ip: '10.0.0.1', src_port: 5000, dest_ip: '8.8.8.8', dest_port: 53 },
+            }],
+          },
+        }],
+        meta: { count: 1 },
+      },
+    },
+  });
+  // The protocol should render as UDP (not "unknown" — which was the old protocol/proto mismatch bug).
+  assert.match(out.text, /UDP 10.0.0.1:5000 -> 8.8.8.8:53/);
+  assert.doesNotMatch(out.text, /unknown 10.0.0.1/);
+});
+
+test('formatFileResults: minimal payload does not throw', () => {
+  const out = formatFileResults({});
+  assert.match(out.text, /File Analysis Results/);
+});
+
+// ---------- url / ip / domain ----------
+
+test('formatUrlScanResults: handles missing relationships', () => {
+  const out = formatUrlScanResults({ url: 'https://example.com', attributes: { last_analysis_stats: { malicious: 0, harmless: 90, undetected: 5, suspicious: 0 } } });
+  assert.match(out.text, /URL Analysis Results/);
+  assert.match(out.text, /example.com/);
+});
+
+test('formatIpResults: minimal', () => {
+  const out = formatIpResults({ id: '1.1.1.1', attributes: {} });
+  assert.match(out.text, /IP Address Analysis/);
+  assert.match(out.text, /1.1.1.1/);
+});
+
+test('formatDomainResults: minimal', () => {
+  const out = formatDomainResults({ id: 'example.com', attributes: {} });
+  assert.match(out.text, /Domain Analysis Results/);
+  assert.match(out.text, /example.com/);
+});


### PR DESCRIPTION
Bug fixes
- handlers/{url,file,ip}.ts: relationship handlers built a `params`
  object with limit/cursor and never passed it to queryVirusTotal, so
  pagination was silently broken
- formatters/file.ts: IDS alert_context uses `proto`, not `protocol`
  (the field name VT's example JSON uses; their description text was
  wrong)
- handlers/url.ts: stop re-scanning on every call. GET the cached
  report first; only POST + poll /analyses/{id} on 404. Replaces the
  fixed 3s sleep, which routinely returned incomplete attributes
- utils/api.ts: don't throw at module load when the API key is unset.
  Lazy-init the axios client; call initVirusTotalClient() from main()
  so failures surface cleanly instead of crashing before the MCP
  transport is established
- utils/api.ts: drop the duplicate dotenv.config() (also called in
  index.ts)
- index.ts: read version from package.json instead of hardcoding 1.0.0
- index.ts: make unhandledRejection exit(1) like uncaughtException

Sync relationship lists with current VT v3 docs
(https://virustotal.readme.io/llms.txt, verified May 2026)
- url: add collections, embedded_js_files, urls_related_by_tracker_id,
  user_votes, votes (5 new)
- ip: add collections, user_votes, votes (3 new)
- domain: add collections, votes; ensure graphs is present in the Zod
  enum (it was in RELATIONSHIPS but missing from the schema)
- file: drop `clues` (no longer documented). 40 relationships total
- schemas/index.ts: derive Zod enums from RELATIONSHIPS so the two
  lists can't drift again
- index.ts: tool descriptions read counts from RELATIONSHIPS

Performance
- New queryVirusTotalWithRelationships helper uses VT's
  `?relationships=a,b,c` query and batches at 8 per call. Reduces
  get_file_report from 15 sequential API calls to 2, get_ip_report
  from 7 to 1, get_url_report from 9 to 1-2, get_domain_report from
  N+1 to ceil(N/8). Materially reduces rate-limit pressure under the
  500/day, 4/min public quota.

Other
- Introduce VirusTotalApiError carrying status + VT error code so
  callers can react to 404 etc. without string parsing
- Fix the spread-an-array-into-an-object bug in relationship handler
  responses