### PR TITLE
docs: update README for new tools, synced relationship lists, and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,15 @@ The server exposes a health check endpoint at `/health` when running in HTTP str
 
 ## Features
 
-- **Comprehensive Analysis Reports**: Each analysis tool automatically fetches relevant relationship data along with the basic report, providing a complete security overview in a single request
-- **URL Analysis**: Security reports with automatic fetching of contacted domains, downloaded files, and threat actors
+- **Comprehensive Analysis Reports**: Each analysis tool automatically fetches relevant relationship data along with the basic report using VirusTotal's `?relationships=` query, batched to minimize API calls
+- **URL Analysis**: Cached-report-first lookups with automatic fallback to scanning, plus contacted domains, downloaded files, and threat actors
 - **File Analysis**: Detailed analysis of file hashes including behaviors, dropped files, and network connections
 - **IP Analysis**: Security reports with historical data, resolutions, and related threats
 - **Domain Analysis**: DNS information, WHOIS data, SSL certificates, and subdomains
 - **Detailed Relationship Analysis**: Dedicated tools for querying specific types of relationships with pagination support
+- **Corpus Search**: Free-form search across files, URLs, domains, IPs, and comments, including VTI-style modifier syntax (`type:peexe positives:5+`)
+- **Sandbox Behaviour Summary**: Cross-sandbox merged view of processes, files, registry, network, MITRE ATT&CK, IDS alerts, and signature matches
+- **Threat Collections**: Read APT, malware-family, campaign, and intel-report objects referenced from any report's relationships
 - **Rich Formatting**: Clear categorization and presentation of analysis results and relationship data
 
 ## Tools
@@ -164,7 +167,7 @@ The server exposes a health check endpoint at `/health` when running in HTTP str
 
 ### 1. URL Report Tool
 - Name: `get_url_report`
-- Description: Get a comprehensive URL analysis report including security scan results and key relationships (communicating files, contacted domains/IPs, downloaded files, redirects, threat actors)
+- Description: Get a comprehensive URL analysis report including security scan results and key relationships (communicating files, contacted domains/IPs, downloaded files, redirects, threat actors). Returns the cached VirusTotal report when available; only submits the URL for scanning and polls for completion on a cache miss
 - Parameters:
   * `url` (required): The URL to analyze
 
@@ -191,43 +194,66 @@ The server exposes a health check endpoint at `/health` when running in HTTP str
 
 ### 1. URL Relationship Tool
 - Name: `get_url_relationship`
-- Description: Query a specific relationship type for a URL with pagination support. Choose from 17 relationship types including analyses, communicating files, contacted domains/IPs, downloaded files, graphs, referrers, redirects, and threat actors
+- Description: Query a specific relationship type for a URL with pagination support. Choose from 22 relationship types including analyses, communicating files, contacted domains/IPs, downloaded files, graphs, referrers, redirects, threat actors, collections, and votes
 - Parameters:
   * `url` (required): The URL to get relationships for
   * `relationship` (required): Type of relationship to query
-    - Available relationships: analyses, comments, communicating_files, contacted_domains, contacted_ips, downloaded_files, graphs, last_serving_ip_address, network_location, referrer_files, referrer_urls, redirecting_urls, redirects_to, related_comments, related_references, related_threat_actors, submissions
+    - Available relationships: analyses, collections, comments, communicating_files, contacted_domains, contacted_ips, downloaded_files, embedded_js_files, graphs, last_serving_ip_address, network_location, referrer_files, referrer_urls, redirecting_urls, redirects_to, related_comments, related_references, related_threat_actors, submissions, urls_related_by_tracker_id, user_votes, votes
   * `limit` (optional, default: 10): Maximum number of related objects to retrieve (1-40)
   * `cursor` (optional): Continuation cursor for pagination
 
 ### 2. File Relationship Tool
 - Name: `get_file_relationship`
-- Description: Query a specific relationship type for a file with pagination support. Choose from 41 relationship types including behaviors, network connections, dropped files, embedded content, execution chains, and threat actors
+- Description: Query a specific relationship type for a file with pagination support. Choose from 40 relationship types including behaviors, network connections, dropped files, embedded content, execution chains, and threat actors
 - Parameters:
   * `hash` (required): MD5, SHA-1 or SHA-256 hash of the file
   * `relationship` (required): Type of relationship to query
-    - Available relationships: analyses, behaviours, bundled_files, carbonblack_children, carbonblack_parents, ciphered_bundled_files, ciphered_parents, clues, collections, comments, compressed_parents, contacted_domains, contacted_ips, contacted_urls, dropped_files, email_attachments, email_parents, embedded_domains, embedded_ips, embedded_urls, execution_parents, graphs, itw_domains, itw_ips, itw_urls, memory_pattern_domains, memory_pattern_ips, memory_pattern_urls, overlay_children, overlay_parents, pcap_children, pcap_parents, pe_resource_children, pe_resource_parents, related_references, related_threat_actors, similar_files, submissions, screenshots, urls_for_embedded_js, votes
+    - Available relationships: analyses, behaviours, bundled_files, carbonblack_children, carbonblack_parents, ciphered_bundled_files, ciphered_parents, collections, comments, compressed_parents, contacted_domains, contacted_ips, contacted_urls, dropped_files, email_attachments, email_parents, embedded_domains, embedded_ips, embedded_urls, execution_parents, graphs, itw_domains, itw_ips, itw_urls, memory_pattern_domains, memory_pattern_ips, memory_pattern_urls, overlay_children, overlay_parents, pcap_children, pcap_parents, pe_resource_children, pe_resource_parents, related_references, related_threat_actors, similar_files, submissions, screenshots, urls_for_embedded_js, votes
   * `limit` (optional, default: 10): Maximum number of related objects to retrieve (1-40)
   * `cursor` (optional): Continuation cursor for pagination
 
 ### 3. IP Relationship Tool
 - Name: `get_ip_relationship`
-- Description: Query a specific relationship type for an IP address with pagination support. Choose from 12 relationship types including communicating files, historical SSL certificates, WHOIS records, resolutions, and threat actors
+- Description: Query a specific relationship type for an IP address with pagination support. Choose from 15 relationship types including communicating files, historical SSL certificates, WHOIS records, resolutions, threat actors, and votes
 - Parameters:
   * `ip` (required): IP address to analyze
   * `relationship` (required): Type of relationship to query
-    - Available relationships: comments, communicating_files, downloaded_files, graphs, historical_ssl_certificates, historical_whois, related_comments, related_references, related_threat_actors, referrer_files, resolutions, urls
+    - Available relationships: collections, comments, communicating_files, downloaded_files, graphs, historical_ssl_certificates, historical_whois, related_comments, related_references, related_threat_actors, referrer_files, resolutions, urls, user_votes, votes
   * `limit` (optional, default: 10): Maximum number of related objects to retrieve (1-40)
   * `cursor` (optional): Continuation cursor for pagination
 
 ### 4. Domain Relationship Tool
 - Name: `get_domain_relationship`
-- Description: Query a specific relationship type for a domain with pagination support. Choose from 21 relationship types including SSL certificates, subdomains, historical data, and DNS records
+- Description: Query a specific relationship type for a domain with pagination support. Choose from 24 relationship types including SSL certificates, subdomains, historical data, DNS records, and collections
 - Parameters:
   * `domain` (required): Domain name to analyze
   * `relationship` (required): Type of relationship to query
-    - Available relationships: caa_records, cname_records, comments, communicating_files, downloaded_files, historical_ssl_certificates, historical_whois, immediate_parent, mx_records, ns_records, parent, referrer_files, related_comments, related_references, related_threat_actors, resolutions, soa_records, siblings, subdomains, urls, user_votes
+    - Available relationships: caa_records, cname_records, collections, comments, communicating_files, downloaded_files, graphs, historical_ssl_certificates, historical_whois, immediate_parent, mx_records, ns_records, parent, referrer_files, related_comments, related_references, related_threat_actors, resolutions, soa_records, siblings, subdomains, urls, user_votes, votes
   * `limit` (optional, default: 10): Maximum number of related objects to retrieve (1-40)
   * `cursor` (optional): Continuation cursor for pagination
+
+### Search & Pivot Tools
+
+### 1. Corpus Search
+- Name: `search_vt`
+- Description: Search the VirusTotal corpus for files, URLs, domains, IPs, or comments matching a query. Accepts plain IOCs (hash, URL, domain, IP), free text against comments, or VTI-style search modifiers
+- Parameters:
+  * `query` (required): Search query. Examples: a SHA-256 hash, `evil.com`, `8.8.8.8`, `type:peexe size:90kb+ tag:signed positives:5+`
+  * `limit` (optional, default: 20): Maximum number of results (1-300)
+  * `cursor` (optional): Continuation cursor for pagination
+
+### 2. File Behaviour Summary
+- Name: `get_file_behaviour_summary`
+- Description: Get a consolidated sandbox behaviour summary for a file, merged across every sandbox that analyzed it. Returns processes, files, registry, network activity, DNS lookups, MITRE ATT&CK techniques, IDS alerts, and signature matches in a single view — far more useful than iterating individual behaviour reports
+- Parameters:
+  * `hash` (required): MD5, SHA-1 or SHA-256 hash of the file
+
+### 3. Collection Lookup
+- Name: `get_collection`
+- Description: Retrieve a VirusTotal collection by ID. Collections represent threat actors, malware families, campaigns, intel reports, and curated IOC sets — often referenced from the `related_threat_actors` and `collections` relationships on other tools. Optionally include relationships to fetch member IOCs in the same call
+- Parameters:
+  * `id` (required): Collection ID (e.g. `threat-actor--<uuid>`, `malware-family--<id>`)
+  * `relationships` (optional): Array of relationship names to include (e.g. `["files", "urls", "domains", "ip_addresses", "references", "threat_actors", "attack_techniques"]`)
 
 ## Requirements
 
@@ -257,6 +283,22 @@ To run in development mode with hot reloading:
 npm run dev
 ```
 
+## Testing
+
+### Unit tests
+Run the formatter test suite (no API key, no network):
+```bash
+npm test
+```
+
+### Live smoke test
+Exercise all 11 tools end-to-end against the real VirusTotal API:
+```bash
+VIRUSTOTAL_API_KEY=your-key npm run smoke
+```
+
+The smoke test paces calls at 20 s to stay under the 4-requests-per-minute public-tier rate limit. **It is not compatible with heavily reduced free tiers (e.g. 1 lookup/day)** — for those, run a single tool by editing `scripts/smoke-test.mjs` and pick the one you want to verify.
+
 ## Error Handling
 
 The server includes comprehensive error handling for:
@@ -278,6 +320,7 @@ The server includes comprehensive error handling for:
 - v1.3.0: Added pagination support for relationship queries
 - v1.4.0: Added automatic relationship fetching in report tools and domain analysis support
 - v1.5.0: Migrated to FastMCP framework with HTTP streaming transport support
+- v1.6.0: Added `search_vt`, `get_file_behaviour_summary`, `get_collection`, and `get_domain_relationship` tools; synced relationship lists with current VirusTotal v3 docs (drops removed `clues`, adds `collections`/`votes`/`user_votes`/`embedded_js_files`/`urls_related_by_tracker_id` where applicable); `get_url_report` now returns the cached report when available instead of re-scanning on every call; report tools use batched `?relationships=` queries for dramatically fewer API calls
 
 ## Contributing
 


### PR DESCRIPTION
Follow-up to the v1.6.0 changes that were merged without the README updates.

## What changed

- Added the four new tools to the Tools section: `search_vt`, `get_file_behaviour_summary`, `get_collection` (under a new "Search & Pivot Tools" subsection), and the newly-wired `get_domain_relationship`.
- Synced the relationship enums and counts on all four relationship tools against current VirusTotal v3 docs:
  - URL: 17 → 22 (added `collections`, `embedded_js_files`, `urls_related_by_tracker_id`, `user_votes`, `votes`)
  - File: 41 → 40 (dropped removed `clues`)
  - IP: 12 → 15 (added `collections`, `user_votes`, `votes`)
  - Domain: 21 → 24 (added `collections`, `graphs`, `votes`)
- Noted that `get_url_report` now returns the cached report when available and only re-scans on cache miss.
- Added a Testing section covering `npm test` (unit) and `npm run smoke` (live), with a caveat about heavily reduced free tiers.
- Added a v1.6.0 entry to the version history.

Quick Start, install, Docker, env vars, and troubleshooting sections are untouched.

## Test plan
- [ ] Read through the diff to confirm tool descriptions match what's in `src/index.ts`
- [ ] Verify relationship lists in README match `RELATIONSHIPS` in `src/utils/api.ts`


---
_Generated by [Claude Code](https://claude.ai/code/session_0132b6v1NUMa5USd5gAEb755)_