### PR TITLE
Drop parent-shell preamble from *_relationship handlers

### DIFF
--- a/src/formatters/file.ts
+++ b/src/formatters/file.ts
@@ -63,9 +63,9 @@ interface AnalysisStats {
   timeout: number;
 }
 
-function formatRelationshipData(relType: string, item: any): string {
+export function formatRelationshipData(relType: string, item: any): string {
   const attrs = item.attributes || {};
-  
+
   switch (relType) {
     case 'behaviours':
       const activities = [

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -2,11 +2,11 @@
 
 export { FormattedResult } from './types.js';
 export { formatDateTime, formatPercentage, formatDetectionResults } from './utils.js';
-export { formatUrlScanResults, UrlData } from './url.js';
-export { formatFileResults } from './file.js';
-export { formatIpResults } from './ip.js';
+export { formatUrlScanResults, UrlData, formatRelationshipData as formatUrlRelationshipItem } from './url.js';
+export { formatFileResults, formatRelationshipData as formatFileRelationshipItem } from './file.js';
+export { formatIpResults, formatRelationshipData as formatIpRelationshipItem } from './ip.js';
 export { formatDomainResults } from './domain.js';
-export { formatRelationshipResults } from './relationship.js';
+export { formatRelationshipResults, formatRelationshipPage } from './relationship.js';
 export { formatSearchResults } from './search.js';
 export { formatBehaviourSummary } from './behaviour.js';
 export { formatCollectionResults } from './collection.js';

--- a/src/formatters/ip.ts
+++ b/src/formatters/ip.ts
@@ -71,7 +71,7 @@ interface IpData {
   relationships?: Record<string, RelationshipData>;
 }
 
-function formatRelationshipData(relType: string, item: any): string {
+export function formatRelationshipData(relType: string, item: any): string {
   const attrs = item.attributes || {};
   
   switch (relType) {

--- a/src/formatters/relationship.ts
+++ b/src/formatters/relationship.ts
@@ -3,6 +3,73 @@
 import { FormattedResult } from './types.js';
 import { logToFile } from '../utils/logging.js';
 
+type EntityType = 'url' | 'file' | 'ip' | 'domain';
+
+const ENTITY_EMOJI: Record<EntityType, string> = {
+  url: '🔗',
+  file: '📁',
+  ip: '🌐',
+  domain: '🌍',
+};
+
+const ENTITY_LABEL: Record<EntityType, string> = {
+  url: 'URL',
+  file: 'File',
+  ip: 'IP',
+  domain: 'Domain',
+};
+
+export interface RelationshipPageOptions {
+  entity: EntityType;
+  entityId: string;
+  relationship: string;
+  data: any;
+  meta?: { count?: number; cursor?: string };
+  renderItem: (relationship: string, item: any) => string;
+}
+
+/**
+ * Render a focused page of relationship items for one entity, without the
+ * noisy parent-entity preamble produced by the full report formatters.
+ */
+export function formatRelationshipPage(opts: RelationshipPageOptions): FormattedResult {
+  try {
+    const { entity, entityId, relationship, data, meta = {}, renderItem } = opts;
+    const items = Array.isArray(data) ? data : data ? [data] : [];
+    const total = meta.count;
+
+    const header = `${ENTITY_EMOJI[entity]} ${ENTITY_LABEL[entity]} ${entityId} — ${relationship}`;
+    const counts =
+      total != null && total !== items.length
+        ? `Showing ${items.length} of ${total} items.`
+        : `${items.length} item${items.length === 1 ? '' : 's'}.`;
+
+    const lines: string[] = [header, counts, ''];
+
+    if (items.length === 0) {
+      lines.push('(no results)');
+    } else {
+      for (const item of items) {
+        try {
+          lines.push(renderItem(relationship, item));
+        } catch (err) {
+          logToFile(`Error formatting relationship item: ${err}`);
+          lines.push('  • Error formatting item');
+        }
+      }
+    }
+
+    if (meta.cursor) {
+      lines.push('', `📄 More results available. Use cursor: ${meta.cursor}`);
+    }
+
+    return { type: 'text', text: lines.join('\n') };
+  } catch (error) {
+    logToFile(`Error formatting relationship page: ${error}`);
+    return { type: 'text', text: 'Error formatting relationship page' };
+  }
+}
+
 export function formatRelationshipResults(data: any, type: 'url' | 'file' | 'ip' | 'domain'): FormattedResult {
   try {
     const relationshipData = data?.data || [];

--- a/src/formatters/url.ts
+++ b/src/formatters/url.ts
@@ -64,9 +64,9 @@ export interface UrlData {
   relationships?: Record<string, RelationshipData>;
 }
 
-function formatRelationshipData(relType: string, item: any): string {
+export function formatRelationshipData(relType: string, item: any): string {
   const attrs = item.attributes || {};
-  
+
   switch (relType) {
     case 'communicating_files':
     case 'downloaded_files':

--- a/src/handlers/domain.ts
+++ b/src/handlers/domain.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
-import { formatDomainResults } from '../formatters/index.js';
+import { formatDomainResults, formatRelationshipPage } from '../formatters/index.js';
 import {
   GetDomainReportArgsSchema,
   GetDomainRelationshipArgsSchema,
@@ -156,31 +156,15 @@ export async function handleGetDomainRelationship(
     params,
   );
 
-  // Attach formattedOutput for the existing domain formatter.
-  const relationshipData: Record<string, RelationshipData> = {};
-  if (Array.isArray(result.data)) {
-    relationshipData[relationship] = {
-      data: result.data.map((item: RelationshipItem) => ({
-        ...item,
-        formattedOutput: formatRelationshipData(relationship, item),
-      })),
-      meta: result.meta,
-    };
-  } else if (result.data) {
-    relationshipData[relationship] = {
-      data: {
-        ...result.data,
-        formattedOutput: formatRelationshipData(relationship, result.data),
-      },
-      meta: result.meta,
-    };
-  }
-
   return {
     content: [
-      formatDomainResults({
-        id: domain,
-        relationships: relationshipData,
+      formatRelationshipPage({
+        entity: 'domain',
+        entityId: domain,
+        relationship,
+        data: result.data,
+        meta: result.meta,
+        renderItem: formatRelationshipData,
       }),
     ],
   };

--- a/src/handlers/file.ts
+++ b/src/handlers/file.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
-import { formatFileResults, formatBehaviourSummary } from '../formatters/index.js';
+import {
+  formatFileResults,
+  formatFileRelationshipItem,
+  formatBehaviourSummary,
+  formatRelationshipPage,
+} from '../formatters/index.js';
 import {
   GetFileReportArgsSchema,
   GetFileRelationshipArgsSchema,
@@ -52,13 +57,13 @@ export async function handleGetFileRelationship(args: z.infer<typeof GetFileRela
 
   return {
     content: [
-      formatFileResults({
-        relationships: {
-          [relationship]: {
-            data: result.data,
-            meta: result.meta,
-          },
-        },
+      formatRelationshipPage({
+        entity: 'file',
+        entityId: hash,
+        relationship,
+        data: result.data,
+        meta: result.meta,
+        renderItem: formatFileRelationshipItem,
       }),
     ],
   };

--- a/src/handlers/ip.ts
+++ b/src/handlers/ip.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { queryVirusTotal, queryVirusTotalWithRelationships } from '../utils/api.js';
-import { formatIpResults } from '../formatters/index.js';
+import {
+  formatIpResults,
+  formatIpRelationshipItem,
+  formatRelationshipPage,
+} from '../formatters/index.js';
 import { GetIpReportArgsSchema, GetIpRelationshipArgsSchema } from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
 
@@ -40,14 +44,13 @@ export async function handleGetIpRelationship(args: z.infer<typeof GetIpRelation
 
   return {
     content: [
-      formatIpResults({
-        id: ip,
-        relationships: {
-          [relationship]: {
-            data: result.data,
-            meta: result.meta,
-          },
-        },
+      formatRelationshipPage({
+        entity: 'ip',
+        entityId: ip,
+        relationship,
+        data: result.data,
+        meta: result.meta,
+        renderItem: formatIpRelationshipItem,
       }),
     ],
   };

--- a/src/handlers/url.ts
+++ b/src/handlers/url.ts
@@ -5,7 +5,11 @@ import {
   encodeUrlForVt,
   VirusTotalApiError,
 } from '../utils/api.js';
-import { formatUrlScanResults } from '../formatters/index.js';
+import {
+  formatUrlScanResults,
+  formatUrlRelationshipItem,
+  formatRelationshipPage,
+} from '../formatters/index.js';
 import { GetUrlReportArgsSchema, GetUrlRelationshipArgsSchema } from '../schemas/index.js';
 import { logToFile } from '../utils/logging.js';
 
@@ -87,14 +91,13 @@ export async function handleGetUrlRelationship(args: z.infer<typeof GetUrlRelati
 
   return {
     content: [
-      formatUrlScanResults({
-        url,
-        relationships: {
-          [relationship]: {
-            data: result.data,
-            meta: result.meta,
-          },
-        },
+      formatRelationshipPage({
+        entity: 'url',
+        entityId: url,
+        relationship,
+        data: result.data,
+        meta: result.meta,
+        renderItem: formatUrlRelationshipItem,
       }),
     ],
   };


### PR DESCRIPTION
## Summary

The four `*_relationship` handlers wrapped the API response in an empty parent-entity shell before passing it to the full report formatter. The formatter then rendered a misleading preamble (`AS Owner: Unknown / Reputation: N/A / ...`) above the actual relationship items. The shell also dropped `meta.cursor`, so paging through results was unreachable from the response.

- New `formatRelationshipPage({entity, entityId, relationship, data, meta, renderItem})` in `src/formatters/relationship.ts` renders a focused header (`🌐 IP 8.8.8.8 — resolutions`), `Showing N of M items.`, the items, and a cursor line when present.
- Per-relationship-type `formatRelationshipData` is now exported from `ip.ts`, `file.ts`, `url.ts` and re-exported via `src/formatters/index.ts` as `format{Ip,File,Url}RelationshipItem`. The domain handler keeps its existing local renderer.
- `handleGet{Ip,File,Url,Domain}Relationship` route through the new helper instead of wrapping in the parent shell. The four `*_report` tools are untouched — they still render full parent context plus the relationship section.

### Before / after — `get_ip_relationship 8.8.8.8 resolutions limit:3`

Before:
```
🌐 IP Address Analysis
IP: 8.8.8.8
📍 Network Information:
• AS Owner: Unknown
• Network: Unknown
• Country: Unknown
...
📊 Analysis Statistics:
No detection results available
👥 Community Feedback:
• Reputation Score: N/A
...
🔗 Relationships:

resolutions (200 items):
  • Host: xixia.diankaibao.cn
    Last Resolved: 5/23/2026, 9:32:19 PM
  ...
```

After:
```
🌐 IP 8.8.8.8 — resolutions
Showing 3 of 200 items.

  • Host: xixia.diankaibao.cn
    Last Resolved: 5/23/2026, 9:32:19 PM
  • Host: m.xixia.diankaibao.cn
    Last Resolved: 5/23/2026, 9:32:14 PM
  • Host: home132.cc.cd
    Last Resolved: 5/23/2026, 9:23:28 PM

📄 More results available. Use cursor: ClIK...
```

## Test plan

- [x] `npm test` — 13/13 unit tests pass
- [x] `npm run smoke` — 10/11 live tests pass; the one failure is the intentional 404 probe (`get_collection threat-actor--apt28`, test name says "probably-404"), unchanged from baseline
- [x] Live exercise of all four `*_relationship` handlers (ip resolutions, domain subdomains, url contacted_domains, file similar_files) — focused output, cursor surfaced where present, clean "(no results)" for empty
- [x] Live `get_ip_report` — confirmed parent-entity report tools still render full context + relationship section

🤖 Generated with [Claude Code](https://claude.com/claude-code)